### PR TITLE
Making the background thread a daemon

### DIFF
--- a/speech_recognition/__init__.py
+++ b/speech_recognition/__init__.py
@@ -355,6 +355,7 @@ class Recognizer(AudioSource):
                 with source as s: audio = self.listen(s)
                 callback(self, audio)
         listener_thread = threading.Thread(target=threaded_listen)
+        listener_thread.daemon = True
         listener_thread.start()
         return listener_thread
 


### PR DESCRIPTION
By making it a daemon, a user doesn't have to worry about manually shutting down the thread started by listen_in_background