### PR TITLE
Fixed: read suppresses errors on overflow

### DIFF
--- a/speech_recognition/__init__.py
+++ b/speech_recognition/__init__.py
@@ -346,7 +346,7 @@ class Recognizer(AudioSource):
                 if timeout and elapsed_time > timeout: # handle timeout if specified
                     raise WaitTimeoutError("listening timed out")
 
-                buffer = source.stream.read(source.CHUNK)
+                buffer = source.stream.read(source.CHUNK, exception_on_overflow = False)
                 if len(buffer) == 0: break # reached end of the stream
                 frames.append(buffer)
                 if len(frames) > non_speaking_buffer_count: # ensure we only keep the needed amount of non-speaking buffers
@@ -367,7 +367,7 @@ class Recognizer(AudioSource):
             while True:
                 elapsed_time += seconds_per_buffer
 
-                buffer = source.stream.read(source.CHUNK)
+                buffer = source.stream.read(source.CHUNK, exception_on_overflow = False)
                 if len(buffer) == 0: break # reached end of the stream
                 frames.append(buffer)
                 phrase_count += 1


### PR DESCRIPTION
This stops the “OSError: [Errno Input overflowed] -9981” from
interrupting program flow when doing listen_in_background().

I had issue #70 as well, this pull request fixes it. 

See this [Stack Exchange](http://stackoverflow.com/a/35168465/5935090) answer for a tiny bit more detail. 