### PR TITLE
Api ai support

### DIFF
--- a/examples/wav_transcribe.py
+++ b/examples/wav_transcribe.py
@@ -49,6 +49,17 @@ except sr.UnknownValueError:
 except sr.RequestError as e:
     print("Could not request results from IBM Speech to Text service; {0}".format(e))
 
+# recognize speech using api.ai Speech to Text
+# Note: Use the developer access token for managing entities and intents, and use the client access token for making queries.
+API_AI_CLIENT_ACCESS_TOKEN = "INSERT API.AI SPEECH TO TEXT ACCESS TOKEN HERE"  # api.ai access tokens are 32-character lowercase alphanumeric strings
+API_AI_SUBSCRIPTION_KEY = "INSERT API.AI SPEECH TO TEXT SUBSCRIPTION KEY HERE"  # api.ai subscription_keys are strings of the form XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+try:
+    print("api.ai Speech to Text thinks you said " + r.recognize_api(audio, username=API_AI_CLIENT_ACCESS_TOKEN, password=API_AI_SUBSCRIPTION_KEY))
+except sr.UnknownValueError:
+    print("api.ai Speech to Text could not understand audio")
+except sr.RequestError as e:
+    print("Could not request results from api.ai Speech to Text service; {0}".format(e))
+
 # recognize speech using AT&T Speech to Text
 ATT_APP_KEY = "INSERT AT&T SPEECH TO TEXT APP KEY HERE" # AT&T Speech to Text app keys are 32-character lowercase alphanumeric strings
 ATT_APP_SECRET = "INSERT AT&T SPEECH TO TEXT APP SECRET HERE" # AT&T Speech to Text app secrets are 32-character lowercase alphanumeric strings


### PR DESCRIPTION
I added a method in the Recognizer class to support queries to the api.ai speech recognition engine (https://api.ai/). I also added an example usage to wav_transcribe.py. Api.ai supports a lot of languages, but I made English the default. Also, api.ai only accepts 16k audio.