### PR TITLE
Always return transcription with highest confidence in recognize_google()

### DIFF
--- a/speech_recognition/__init__.py
+++ b/speech_recognition/__init__.py
@@ -21,6 +21,7 @@ import time
 import uuid
 import tempfile
 import shutil
+from operator import itemgetter
 
 __author__ = "Anthony Zhang (Uberi)"
 __version__ = "3.5.0"
@@ -736,10 +737,9 @@ class Recognizer(AudioSource):
         # return results
         if show_all: return actual_result
         if "alternative" not in actual_result: raise UnknownValueError()
-        for entry in actual_result["alternative"]:
-            if "transcript" in entry:
-                return entry["transcript"]
-        raise UnknownValueError()  # no transcriptions available
+        alternatives = actual_result["alternative"]
+        # return alternative with highest confidence score
+        return sorted(alternatives, key=itemgetter("confidence"))[-1]
 
     def recognize_google_cloud(self, audio_data, language="en-US", preferred_phrases=None, show_all=False):
         """


### PR DESCRIPTION
Fixes https://github.com/Uberi/speech_recognition/issues/177

Removed checking for "transcript" key since the Speech API should always be returning that.