### PR TITLE
Treats the situation when google API is called and no confidence is returned

### DIFF
--- a/speech_recognition/__init__.py
+++ b/speech_recognition/__init__.py
@@ -737,8 +737,12 @@ class Recognizer(AudioSource):
         if show_all: return actual_result
         if not isinstance(actual_result, dict) or len(actual_result.get("alternative", [])) == 0: raise UnknownValueError()
 
-        # return alternative with highest confidence score
-        best_hypothesis = max(actual_result["alternative"], key=lambda alternative: alternative["confidence"])
+        if "confidence" in actual_result["alternative"]:
+            # return alternative with highest confidence score
+            best_hypothesis = max(actual_result["alternative"], key=lambda alternative: alternative["confidence"])
+        else:
+            # when there is no confidence available, we arbitrarily choose the first hypothesis.
+            best_hypothesis = actual_result["alternative"][0]
         if "transcript" not in best_hypothesis: raise UnknownValueError()
         return best_hypothesis["transcript"]
 


### PR DESCRIPTION
You will be able to reproduce the problem with the attached wav files (that were zipped). nok.wav is the "problematic sample". ok.wav works fine.

To reproduce the problem, just call google_recognize with the given wav file and **language="pt-BR"**. It should break your application when trying to decode nok.wav. If you print what was transcribed, you will see:

{'alternative': [{'transcript': 'jogador do Palmeiras foi o único que nasceu 3 vezes'}, {'transcript': 'jogador do Palmeiras foi o único que nasceu três vezes'}, {'transcript': 'jogador do Palmeiras foi o único que nas outras vezes'}, {'transcript': 'jogador do Palmeiras foi o único que nasceu o 3 vezes'}, {'transcript': 'jogador do Palmeiras foi o único que nasceu o três vezes'}], 'final': True}

And there is no confidence in this case!

When transcribing ok.wav, everything goes fine, and confidence is returned:

{'alternative': [{'confidence': 0.94338334, 'transcript': 'nós somos uma espécie de contingente escolhido do povo brasileiro'}, {'confidence': 0.88366765, 'transcript': 'nós somos uma espécie de contingentes escolhido do povo brasileiro'}, {'confidence': 0.84510195, 'transcript': 'nós somos uma espécie de contigente escolhido do povo brasileiro'}, {'confidence': 0.87840271, 'transcript': 'nós somos uma espécie de contingent escolhido do povo brasileiro'}, {'confidence': 0.77077204, 'transcript': 'nós somos uma espécie de contingente escolhido o povo brasileiro'}], 'final': True}


[repeat.zip](https://github.com/Uberi/speech_recognition/files/753432/repeat.zip)


