### PR TITLE
Feature add: Version 4 support + Measure & PocketSphinx Directory Expose

### DIFF
--- a/examples/audio_transcribe.py
+++ b/examples/audio_transcribe.py
@@ -1,13 +1,31 @@
 #!/usr/bin/env python3
 
+# new example for testing.
+
 import speech_recognition as sr
-
-# obtain path to "english.wav" in the same folder as this script
 from os import path
-AUDIO_FILE = path.join(path.dirname(path.realpath(__file__)), "english.wav")
-#AUDIO_FILE = path.join(path.dirname(path.realpath(__file__)), "french.aiff")
-#AUDIO_FILE = path.join(path.dirname(path.realpath(__file__)), "chinese.flac")
+import argparse
 
+parser = argparse.ArgumentParser(description='Process some integers.')
+parser.add_argument('file', type=str,
+                    help='file name')
+parser.add_argument('--base',
+                    help='language directory base (default: Speech_Recognition installation directory)')
+parser.add_argument('--language',
+                    help='Used language (default: en_us)')
+
+args = parser.parse_args()
+print args.file
+print "next...."
+print "language dir SET: ",args.base
+print "language SET: ",args.language
+
+AUDIO_FILE = path.join(path.dirname(path.realpath(__file__)), args.file)
+if args.base is not None:
+    LANG_DIR = path.join(path.dirname(path.realpath(__file__)), args.base)
+else:
+    LANG_DIR = None
+    
 # use the audio file as the audio source
 r = sr.Recognizer()
 with sr.AudioFile(AUDIO_FILE) as source:
@@ -15,7 +33,7 @@ with sr.AudioFile(AUDIO_FILE) as source:
 
 # recognize speech using Sphinx
 try:
-    print("Sphinx thinks you said " + r.recognize_sphinx(audio))
+    print("Sphinx thinks you said " + r.recognize_sphinx(audio,args.language,None,False,LANG_DIR))
 except sr.UnknownValueError:
     print("Sphinx could not understand audio")
 except sr.RequestError as e:

--- a/speech_recognition/__init__.py
+++ b/speech_recognition/__init__.py
@@ -624,7 +624,7 @@ class Recognizer(AudioSource):
         energy = audioop.rms(buffer, source.SAMPLE_WIDTH)  # unit energy of the audio signal within the buffer
         return energy
 
-    def recognize_sphinx(self, audio_data, language="en-US", keyword_entries=None, show_all=False, language_directory="acoustic_data"):
+    def recognize_sphinx(self, audio_data, language="en-US", keyword_entries=None, show_all=False, language_base="acoustic_data"):
         """
         Performs speech recognition on ``audio_data`` (an ``AudioData`` instance), using CMU Sphinx.
 
@@ -651,7 +651,7 @@ class Recognizer(AudioSource):
 
         # Weak attempt on making the model directory more exposed.
         # Issue: need to find v4 + v5 config standards
-        if != language_base: language_base = os.path.dirname(os.path.realpath(__file__))
+        if not language_base: language_base = os.path.dirname(os.path.realpath(__file__))
         language_directory = os.path.join(lauguage_base, "pocketsphinx-data", language)
         if not os.path.isdir(language_directory):
             raise RequestError("missing PocketSphinx language data directory: \"{}\"".format(language_directory))

--- a/speech_recognition/__init__.py
+++ b/speech_recognition/__init__.py
@@ -563,7 +563,7 @@ class Recognizer(AudioSource):
 
                 # check if speaking has stopped for longer than the pause threshold on the audio input
                 #energy = audioop.rms(buffer, source.SAMPLE_WIDTH)  # unit energy of the audio signal within the buffer
-                energy = measure_energy(source) # Using new measurement function.
+                energy = self.measure_energy(source) # Using new measurement function.
                 if energy > self.energy_threshold:
                     pause_count = 0
                 else:

--- a/speech_recognition/__init__.py
+++ b/speech_recognition/__init__.py
@@ -562,7 +562,8 @@ class Recognizer(AudioSource):
                 phrase_count += 1
 
                 # check if speaking has stopped for longer than the pause threshold on the audio input
-                energy = audioop.rms(buffer, source.SAMPLE_WIDTH)  # unit energy of the audio signal within the buffer
+                #energy = audioop.rms(buffer, source.SAMPLE_WIDTH)  # unit energy of the audio signal within the buffer
+                energy = measure_energy(source) # Using new measurement function.
                 if energy > self.energy_threshold:
                     pause_count = 0
                 else:
@@ -611,6 +612,17 @@ class Recognizer(AudioSource):
         listener_thread.daemon = True
         listener_thread.start()
         return stopper
+    
+    def measure_energy(self, source):
+        #Will return current energy level measure from source
+        buffer = source.stream.read(source.CHUNK)
+        frames = collections.deque()
+        if len(buffer) == 0: return "To low, mute?" # break  # reached end of the stream
+        frames.append(buffer)
+
+        # This part is a copy from energy measure in LISTEN() function.
+        energy = audioop.rms(buffer, source.SAMPLE_WIDTH)  # unit energy of the audio signal within the buffer
+        return energy
 
     def recognize_sphinx(self, audio_data, language="en-US", keyword_entries=None, show_all=False):
         """

--- a/speech_recognition/__init__.py
+++ b/speech_recognition/__init__.py
@@ -639,7 +639,7 @@ class Recognizer(AudioSource):
         assert isinstance(audio_data, AudioData), "``audio_data`` must be audio data"
         assert isinstance(language, str), "``language`` must be a string"
         assert keyword_entries is None or all(isinstance(keyword, (type(""), type(u""))) and 0 <= sensitivity <= 1 for keyword, sensitivity in keyword_entries), "``keyword_entries`` must be ``None`` or a list of pairs of strings and numbers between 0 and 1"
-        assert isinstance(language_directory, str), "``language_directory`` must be a string"
+        assert isinstance(language_base, str), "``language_base`` must be a string"
 
         # import the PocketSphinx speech recognition module
         try:
@@ -652,7 +652,7 @@ class Recognizer(AudioSource):
         # Weak attempt on making the model directory more exposed.
         # Issue: need to find v4 + v5 config standards
         if not language_base: language_base = os.path.dirname(os.path.realpath(__file__))
-        language_directory = os.path.join(lauguage_base, "pocketsphinx-data", language)
+        language_directory = os.path.join(language_base, "pocketsphinx-data", language)
         if not os.path.isdir(language_directory):
             raise RequestError("missing PocketSphinx language data directory: \"{}\"".format(language_directory))
             


### PR DESCRIPTION
Small line addition for PocketSphinx version detection.

Energy_Measure = so the sound/energy level is directly

PocketSphinx Dir. Expose = So it can be directly pointed to a directory that contains the language models, and directory tree example is in comments.
Next the Language argument will be used next

Most tests are done with PocketSphinx v5 only, as PocketSphinx v4 did not support keywords.
