### PR TITLE
Fixed temporary file bug in Google Cloud api function

### DIFF
--- a/speech_recognition/__init__.py
+++ b/speech_recognition/__init__.py
@@ -800,7 +800,7 @@ class Recognizer(AudioSource):
                 api_credentials = GoogleCredentials.get_application_default()
             else:
                 # the credentials can only be read from a file, so we'll make a temp file and write in the contents to work around that
-                with PortableNamedTemporaryFile("w") as f:
+                with PortableNamedTemporaryFile("w", delete=False) as f:
                     f.write(credentials_json)
                     f.flush()
                     api_credentials = GoogleCredentials.from_stream(f.name)


### PR DESCRIPTION
There was an IOError reading the temporary file. Fixed the bug using that "delete" argument. Please check.