### PR TITLE
Added option to change IBM api url

### DIFF
--- a/speech_recognition/__init__.py
+++ b/speech_recognition/__init__.py
@@ -1148,9 +1148,9 @@ class Recognizer(AudioSource):
             raise UnknownValueError()
         return result['Disambiguation']['ChoiceData'][0]['Transcription']
 
-    def recognize_ibm(self, audio_data, username, password, language="en-US", show_all=False):
+    def recognize_ibm(self, audio_data, username, password, language="en-US", show_all=False, api_url="https://stream.watsonplatform.net/speech-to-text/api/v1/recognize?{}"):
         """
-        Performs speech recognition on ``audio_data`` (an ``AudioData`` instance), using the IBM Speech to Text API.
+        Performs speech recognition on ``audio_data`` (an ``AudioData`` instance), using the + Speech to Text API.
 
         The IBM Speech to Text username and password are specified by ``username`` and ``password``, respectively. Unfortunately, these are not available without `signing up for an account <https://console.ng.bluemix.net/registration/>`__. Once logged into the Bluemix console, follow the instructions for `creating an IBM Watson service instance <https://www.ibm.com/watson/developercloud/doc/getting_started/gs-credentials.shtml>`__, where the Watson service is "Speech To Text". IBM Speech to Text usernames are strings of the form XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX, while passwords are mixed-case alphanumeric strings.
 
@@ -1168,7 +1168,7 @@ class Recognizer(AudioSource):
             convert_rate=None if audio_data.sample_rate >= 16000 else 16000,  # audio samples should be at least 16 kHz
             convert_width=None if audio_data.sample_width >= 2 else 2  # audio samples should be at least 16-bit
         )
-        url = "https://stream.watsonplatform.net/speech-to-text/api/v1/recognize?{}".format(urlencode({
+        url = api_url.format(urlencode({
             "profanity_filter": "false",
             "model": "{}_BroadbandModel".format(language),
             "inactivity_timeout": -1,  # don't stop recognizing when the audio stream activity stops

--- a/speech_recognition/__init__.py
+++ b/speech_recognition/__init__.py
@@ -1156,8 +1156,10 @@ class Recognizer(AudioSource):
 
         The recognition language is determined by ``language``, an RFC5646 language tag with a dialect like ``"en-US"`` (US English) or ``"zh-CN"`` (Mandarin Chinese), defaulting to US English. The supported language values are listed under the ``model`` parameter of the `audio recognition API documentation <https://www.ibm.com/watson/developercloud/speech-to-text/api/v1/#sessionless_methods>`__, in the form ``LANGUAGE_BroadbandModel``, where ``LANGUAGE`` is the language value.
 
-        Returns the most likely transcription if ``show_all`` is false (the default). Otherwise, returns the `raw API response <https://www.ibm.com/watson/developercloud/speech-to-text/api/v1/#sessionless_methods>`__ as a JSON dictionary.
+        It uses the default watson api ``"https://stream.watsonplatform.net/speech-to-text/api/v1/recognize?{}"`` if not defined otherwise by ``api_url``. Other urls might be more efficient, e.g. the German server url is: ``"https://stream-fra.watsonplatform.net/speech-to-text/api"``.
 
+        Returns the most likely transcription if ``show_all`` is false (the default). Otherwise, returns the `raw API response <https://www.ibm.com/watson/developercloud/speech-to-text/api/v1/#sessionless_methods>`__ as a JSON dictionary.
+        
         Raises a ``speech_recognition.UnknownValueError`` exception if the speech is unintelligible. Raises a ``speech_recognition.RequestError`` exception if the speech recognition operation failed, if the key isn't valid, or if there is no internet connection.
         """
         assert isinstance(audio_data, AudioData), "Data must be audio data"


### PR DESCRIPTION
I added a parameter `api_url` to the `recognize_ibm` function to set the IBM API url manually, since the default url may introduce higher latency.

The issue, i tried to fix, was mentioned here #275 .