### PR TITLE
Fix for OSError: [Errno -9988] Stream closed Error

### DIFF
--- a/speech_recognition/__init__.py
+++ b/speech_recognition/__init__.py
@@ -179,7 +179,7 @@ class Microphone(AudioSource):
                     rate=self.SAMPLE_RATE, frames_per_buffer=self.CHUNK, input=True,
                 )
             )
-        finally:
+        except Exception:
             self.audio.terminate()
         return self
 


### PR DESCRIPTION
Getting 
File "/home/chriamue/Temp/speech_recognition/speech_recognition/__init__.py", line 188, in __exit__
    self.stream.close()
  File "/home/chriamue/Temp/speech_recognition/speech_recognition/__init__.py", line 203, in close
    if not self.pyaudio_stream.is_stopped():
  File "/usr/local/lib/python3.5/dist-packages/pyaudio.py", line 543, in is_stopped
    return pa.is_stream_stopped(self._stream)
OSError: [Errno -9988] Stream closed

because the microphone stream is always closed with finally.
Terminating it only if exceptions occur should fix it.