### PR TITLE
Add support to microphones containing multiple channels

### DIFF
--- a/speech_recognition/__init__.py
+++ b/speech_recognition/__init__.py
@@ -69,11 +69,14 @@ class Microphone(AudioSource):
     Higher ``sample_rate`` values result in better audio quality, but also more bandwidth (and therefore, slower recognition). Additionally, some CPUs, such as those in older Raspberry Pi models, can't keep up if this value is too high.
 
     Higher ``chunk_size`` values help avoid triggering on rapidly changing ambient noise, but also makes detection less sensitive. This value, generally, should be left at its default.
+
+    Some microphones provide two or more ``channels``, but most of microphones have only one channel of input.
     """
-    def __init__(self, device_index=None, sample_rate=None, chunk_size=1024):
+    def __init__(self, device_index=None, sample_rate=None, chunk_size=1024, channels=1):
         assert device_index is None or isinstance(device_index, int), "Device index must be None or an integer"
         assert sample_rate is None or (isinstance(sample_rate, int) and sample_rate > 0), "Sample rate must be None or a positive integer"
         assert isinstance(chunk_size, int) and chunk_size > 0, "Chunk size must be a positive integer"
+        assert isinstance(channels, int) and channels > 0 and channels < 100, "Channels must be a positive integer between 1 and 99"
 
         # set up PyAudio
         self.pyaudio_module = self.get_pyaudio()
@@ -94,6 +97,7 @@ class Microphone(AudioSource):
         self.SAMPLE_WIDTH = self.pyaudio_module.get_sample_size(self.format)  # size of each sample
         self.SAMPLE_RATE = sample_rate  # sampling rate in Hertz
         self.CHUNK = chunk_size  # number of frames stored in each buffer
+        self.CHANNELS = channels # number of channels provided by the microphone
 
         self.audio = None
         self.stream = None
@@ -175,7 +179,7 @@ class Microphone(AudioSource):
         try:
             self.stream = Microphone.MicrophoneStream(
                 self.audio.open(
-                    input_device_index=self.device_index, channels=1, format=self.format,
+                    input_device_index=self.device_index, channels=self.CHANNELS, format=self.format,
                     rate=self.SAMPLE_RATE, frames_per_buffer=self.CHUNK, input=True,
                 )
             )


### PR DESCRIPTION
Microphones such as the ReSpeaker Array v2 contain multiple channels. Since speech_recognition does not provide support for multiple channels in its Microphone class, I added the support for it.