### PR TITLE
Fix failing unit test in google recognition

### DIFF
--- a/tests/test_recognition.py
+++ b/tests/test_recognition.py
@@ -21,7 +21,7 @@ class TestRecognition(unittest.TestCase):
     def test_google_english(self):
         r = sr.Recognizer()
         with sr.AudioFile(self.AUDIO_FILE_EN) as source: audio = r.record(source)
-        self.assertIn(r.recognize_google(audio), ["1 2 3", "one two three"])
+        self.assertIn(r.recognize_google(audio), ["1 2 3", "one two three", "123"])
 
     def test_google_french(self):
         r = sr.Recognizer()


### PR DESCRIPTION
Unit test is failing because the audio is recognized as a "123" instead of "1 2 3" (same with spaces)