### PR TITLE
fix: remove the requirement for defining GOOGLE_APPLICATION_CREDENTIALS

### DIFF
--- a/speech_recognition/__init__.py
+++ b/speech_recognition/__init__.py
@@ -922,8 +922,6 @@ class Recognizer(AudioSource):
         Raises a ``speech_recognition.UnknownValueError`` exception if the speech is unintelligible. Raises a ``speech_recognition.RequestError`` exception if the speech recognition operation failed, if the credentials aren't valid, or if there is no Internet connection.
         """
         assert isinstance(audio_data, AudioData), "``audio_data`` must be audio data"
-        if credentials_json is None:
-            assert os.environ.get('GOOGLE_APPLICATION_CREDENTIALS') is not None
         assert isinstance(language, str), "``language`` must be a string"
         assert preferred_phrases is None or all(isinstance(preferred_phrases, (type(""), type(u""))) for preferred_phrases in preferred_phrases), "``preferred_phrases`` must be a list of strings"
 


### PR DESCRIPTION
`GOOGLE_APPLICATION_CREDENTIALS` or `credential.json` is not a requirement for using Speech Recognition. `GOOGLE_APPLICATION_CREDENTIAL` is the least preferred way of authenticating with a google service. When running on Google Cloud, they inherently have the credentials attached to the infrastructure (using IAM roles), so, `GOOGLE_APPLICATION_CREDENTIALS` is not a hard requirement. At any case, if any environment variable is not defined, or `credentials.json` is not provided or detected by google cloud package, the package will produce an exception. By leaving the authentication part to `google.cloud` package, we can remove the redundant checks from Speech Recognition's code.