### PR TITLE
Update CMUSphinx URL in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ Library for performing speech recognition, with support for several engines and 
 
 Speech recognition engine/API support:
 
-* `CMU Sphinx <http://cmusphinx.sourceforge.net/wiki/>`__ (works offline)
+* `CMU Sphinx <https://cmusphinx.github.io/wiki/>`__ (works offline)
 * Google Speech Recognition
 * `Google Cloud Speech API <https://cloud.google.com/speech/>`__
 * `Wit.ai <https://wit.ai/>`__

--- a/README.rst
+++ b/README.rst
@@ -374,7 +374,7 @@ SpeechRecognition is made available under the 3-clause BSD license. See ``LICENS
 
 For convenience, all the official distributions of SpeechRecognition already include a copy of the necessary copyright notices and licenses. In your project, you can simply **say that licensing information for SpeechRecognition can be found within the SpeechRecognition README, and make sure SpeechRecognition is visible to users if they wish to see it**.
 
-SpeechRecognition distributes source code, binaries, and language files from `CMU Sphinx <http://cmusphinx.sourceforge.net/>`__. These files are BSD-licensed and redistributable as long as copyright notices are correctly retained. See ``speech_recognition/pocketsphinx-data/*/LICENSE*.txt`` and ``third-party/LICENSE-Sphinx.txt`` for license details for individual parts.
+SpeechRecognition distributes source code, binaries, and language files from `CMU Sphinx <https://cmusphinx.github.io/>`__. These files are BSD-licensed and redistributable as long as copyright notices are correctly retained. See ``speech_recognition/pocketsphinx-data/*/LICENSE*.txt`` and ``third-party/LICENSE-Sphinx.txt`` for license details for individual parts.
 
 SpeechRecognition distributes source code and binaries from `PyAudio <http://people.csail.mit.edu/hubert/pyaudio/>`__. These files are MIT-licensed and redistributable as long as copyright notices are correctly retained. See ``third-party/LICENSE-PyAudio.txt`` for license details.
 


### PR DESCRIPTION
Update the CMUSphinx URL in README to point to the new Official URL (from SourceForge to GitHub).

**FROM**: http://cmusphinx.sourceforge.net/wiki/
**TO**: https://cmusphinx.github.io/wiki/