### PR TITLE
Fixed typo at line 59

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ The `library reference <https://github.com/Uberi/speech_recognition/blob/master/
 
 See `Notes on using PocketSphinx <https://github.com/Uberi/speech_recognition/blob/master/reference/pocketsphinx.rst>`__ for information about installing languages, compiling PocketSphinx, and building language packs from online resources. This document is also included under ``reference/pocketsphinx.rst``.
 
-You have to install Vosk models for using Vosk. `Here <https://alphacephei.com/vosk/models>`__ are models avaiable. You have to place them in models folder of your project, like "your-project-folder/models/your-vosk-model"
+You have to install Vosk models for using Vosk. `Here <https://alphacephei.com/vosk/models>`__ are models available. You have to place them in models folder of your project, like "your-project-folder/models/your-vosk-model"
 
 Examples
 --------


### PR DESCRIPTION
Hey there,

I was just scrolling through the readme found this typo. At line 52

Changes
1. available => available