### PR TITLE
Run unittests on pull requests

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Unit tests are passed in Python 3.9 on GitHub Action (ref: https://github.com/Uberi/speech_recognition/pull/619#issuecomment-1195411485),
so I expanded the Python version from 3.7 to 3.10.

I will later modify metadata for PyPI on a separate pull request.