### PR TITLE
Update documentation and code for upcoming PocketSphinx 5 release

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ Library for performing speech recognition, with support for several engines and 
 
 Speech recognition engine/API support:
 
-* `CMU Sphinx <http://cmusphinx.sourceforge.net/wiki/>`__ (works offline)
+* `CMU Sphinx <http://cmusphinx.github.io/>`__ (works offline)
 * Google Speech Recognition
 * `Google Cloud Speech API <https://cloud.google.com/speech/>`__
 * `Wit.ai <https://wit.ai/>`__
@@ -123,14 +123,14 @@ The installation instructions on the PyAudio website are quite good - for conven
 
 PyAudio `wheel packages <https://pypi.python.org/pypi/wheel>`__ for common 64-bit Python versions on Windows and Linux are included for convenience, under the ``third-party/`` `directory <https://github.com/Uberi/speech_recognition/tree/master/third-party>`__ in the repository root. To install, simply run ``pip install wheel`` followed by ``pip install ./third-party/WHEEL_FILENAME`` (replace ``pip`` with ``pip3`` if using Python 3) in the repository `root directory <https://github.com/Uberi/speech_recognition>`__.
 
-PocketSphinx-Python (for Sphinx users)
+PocketSphinx (for Sphinx users)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-`PocketSphinx-Python <https://github.com/bambocher/pocketsphinx-python>`__ is **required if and only if you want to use the Sphinx recognizer** (``recognizer_instance.recognize_sphinx``).
+`PocketSphinx <https://github.com/pocketsphinx>`__ is **required if and only if you want to use the Sphinx recognizer** (``recognizer_instance.recognize_sphinx``).
 
-PocketSphinx-Python `wheel packages <https://pypi.python.org/pypi/wheel>`__ for 64-bit Python 2.7, 3.4, and 3.5 on Windows are included for convenience, under the ``third-party/`` `directory <https://github.com/Uberi/speech_recognition/tree/master/third-party>`__. To install, simply run ``pip install wheel`` followed by ``pip install ./third-party/WHEEL_FILENAME`` (replace ``pip`` with ``pip3`` if using Python 3) in the SpeechRecognition folder.
+PocketSphinx `wheel packages <https://pypi.python.org/pypi/wheel>`__ for 64-bit Python 3.10 on Windows, Linux, and Mac OS X are available on PyPI.  To install, simply run ``pip install --pre pocketsphinx``.
 
-On Linux and other POSIX systems (such as OS X), follow the instructions under "Building PocketSphinx-Python from source" in `Notes on using PocketSphinx <https://github.com/Uberi/speech_recognition/blob/master/reference/pocketsphinx.rst>`__ for installation instructions.
+For other versions of Python or other operating sysgems, follow the instructions under "Building PocketSphinx-Python from source" in `Notes on using PocketSphinx <https://github.com/Uberi/speech_recognition/blob/master/reference/pocketsphinx.rst>`__ for installation instructions.
 
 Note that the versions available in most package repositories are outdated and will not work with the bundled language data. Using the bundled wheel packages or building from source is recommended.
 

--- a/reference/pocketsphinx.rst
+++ b/reference/pocketsphinx.rst
@@ -28,39 +28,30 @@ Here is a simple Bash script to install all of them, assuming you've downloaded 
 
 Once installed, you can simply specify the language using the ``language`` parameter of ``recognizer_instance.recognize_sphinx``. For example, French would be specified with ``"fr-FR"`` and Mandarin with ``"zh-CN"``.
 
-Building PocketSphinx-Python from source
+Building PocketSphinx from source
 ----------------------------------------
 
-For Windows, it is recommended to install the precompiled Wheel packages in the ``third-party`` directory. These are provided because building Pocketsphinx on Windows requires a lot of work, and can take hours to download and install all the surrounding software.
+For Windows, it is recommended to install the precompiled Wheel packages from PyPI using ``pip``. These are provided because building Pocketsphinx on Windows requires a lot of work, and can take hours to download and install all the surrounding software.
 
-For Linux and other POSIX systems (like OS X), you'll want to build from source. It should take less than two minutes on a fast machine.
+For Linux and other POSIX systems (like OS X), some precompiled packages are available, but in many cases you'll need to build from source. It should take less than two minutes on a fast machine.
 
 * On any Debian-derived Linux distributions (like Ubuntu and Mint):
-    1. Run ``sudo apt-get install python python-all-dev python-pip build-essential swig git libpulse-dev libasound2-dev`` for Python 2, or ``sudo apt-get install python3 python3-all-dev python3-pip build-essential swig git libpulse-dev libasound2-dev`` for Python 3.
-    2. Run ``pip install pocketsphinx`` for Python 2, or ``pip3 install pocketsphinx`` for Python 3.
+    1. Run ``sudo apt-get install python3 python3-all-dev python3-pip build-essential``.
+    2. Run ``pip3 install --pre pocketsphinx``.
 * On OS X:
-    1. Run ``brew install swig git python`` for Python 2, or ``brew install swig git python3`` for Python 3.
-    2. Install PocketSphinx-Python using Pip: ``pip install pocketsphinx``.
+    1. Run ``brew install git python3`` for Python 3.
+    2. Install PocketSphinx-Python using Pip: ``pip install --pre pocketsphinx``.
         * If this gives errors when importing the library in your program, try running ``brew link --overwrite python``.
 * On other POSIX-based systems:
-    1. Install `Python <https://www.python.org/downloads/>`__, `Pip <https://pip.pypa.io/en/stable/installing/>`__, `SWIG <http://www.swig.org/download.html>`__, and `Git <https://git-scm.com/downloads>`__, preferably using a package manager.
-    2. Install PocketSphinx-Python using Pip: ``pip install pocketsphinx``.
-* On Windows:
-    1. Install `Python <https://www.python.org/downloads/>`__, `Pip <https://pip.pypa.io/en/stable/installing/>`__, `SWIG <http://www.swig.org/download.html>`__, and `Git <https://git-scm.com/downloads>`__, preferably using a package manager.
+    1. Install `Python <https://www.python.org/downloads/>`__, `Pip <https://pip.pypa.io/en/stable/installing/>`__, and `Git <https://git-scm.com/downloads>`__, preferably using a package manager.
+    2. Install PocketSphinx-Python using Pip: ``pip install --pre pocketsphinx``.
+* On Windows (FIXME: it is not clear this is still correct, Visual Studio URLs change constantly):
+    1. Install `Python <https://www.python.org/downloads/>`__ and `Pip <https://pip.pypa.io/en/stable/installing/>`__
     2. Install the necessary `compilers suite <http://blog.ionelmc.ro/2014/12/21/compiling-python-extensions-on-windows/>`__ (`here's a PDF version <https://github.com/Uberi/speech_recognition/blob/master/third-party/Compiling%20Python%20extensions%20on%20Windows.pdf>`__ in case the link goes down) for compiling modules for your particular Python version:
         * `Microsoft Visual C++ Compiler for Python 2.7 <http://www.microsoft.com/en-us/download/details.aspx?id=44266>`__ for Python 2.7.
-        * `Visual Studio 2015 Community Edition <https://www.visualstudio.com/downloads/download-visual-studio-vs>`__ for Python 3.5.
-        * The installation process for Python 3.4 is outlined in the article above.
-    3. Add the folders containing the Python, SWIG, and Git binaries to your ``PATH`` environment variable.
-        * My ``PATH`` environment variable looks something like: ``C:\Users\Anthony\Desktop\swigwin-3.0.8;C:\Program Files\Git\cmd;(A BUNCH OF OTHER PATHS)``.
-    4. Reboot to apply changes.
-    5. Download the full PocketSphinx-Python source code by running ``git clone --recursive --depth 1 https://github.com/cmusphinx/pocketsphinx-python`` (downloading the ZIP archive from GitHub will not work).
-    6. Run ``python setup.py install`` in the PocketSphinx-Python source code folder to compile and install PocketSphinx.
-    7. Side note: when I build the precompiled Wheel packages, I skip steps 5 and 6 and do the following instead:
-        * For Python 2.7: ``C:\Python27\python.exe setup.py bdist_wheel``.
-        * For Python 3.4: ``C:\Python34\python.exe setup.py bdist_wheel``.
-        * For Python 3.5: ``C:\Users\Anthony\AppData\Local\Programs\Python\Python35\python.exe setup.py bdist_wheel``.
-        * The resulting packages are located in the ``dist`` folder of the PocketSphinx-Python project directory.
+        * `Visual Studio 2015 Community Edition <https://www.visualstudio.com/downloads/download-visual-studio-vs>`__ for Python 3.5 and above.
+    3. Run ``pip install --pre pocketsphinx`` to download, compile and install PocketSphinx.
+    4. Alternately, run ``pip wheel --pre pocketsphinx`` to download and build a wheel of PocketSphinx.
 
 Notes on the structure of the language data
 -------------------------------------------
@@ -80,17 +71,18 @@ Notes on building the language data from source
 
 * All of the following points assume a Debian-derived Linux Distibution (like Ubuntu or Mint).
 * To work with any complete, real-world languages, you will need quite a bit of RAM (16 GB recommended) and a fair bit of disk space (20 GB recommended).
-* `SphinxBase <https://github.com/cmusphinx/sphinxbase>`__ is needed for all language model file format conversions. We use it to convert between ``*.dmp`` DMP files (an obselete Sphinx binary format), ``*.lm`` ARPA files, and Sphinx binary ``*.lm.bin`` files:
-    * Install all the SphinxBase build dependencies with ``sudo apt-get install build-essential automake autotools-dev autoconf libtool``.
-    * Download and extract the `SphinxBase source code <https://github.com/cmusphinx/sphinxbase/archive/master.zip>`__.
-    * Follow the instructions in the README to install SphinxBase. Basically, run ``sh autogen.sh --force && ./configure && make && sudo make install`` in the SphinxBase folder.
+* `PocketSphinx <https://github.com/cmusphinx/pocketsphinx>`__ is needed for all language model file format conversions. We use its `pocketsphinx_lm_convert` tool to convert between ``*.dmp`` DMP files (an obselete Sphinx binary format), ``*.lm`` ARPA files, and Sphinx binary ``*.lm.bin`` files:
+    * Install all the build dependencies with ``sudo apt-get install build-essential cmake``.
+    * Download and extract the `PocketSphinx source code <https://github.com/cmusphinx/pocketsphinx/archive/master.zip>`__.
+    * Follow the instructions in the README to install PocketSphinx. Basically, run ``cmake -S . -B build && cmake --build build && sudo cmake --build build --target install`` in the PocketSphinx folder.
+    * Alternately you can build it in a Docker container using the provided Dockerfile, which is left as an exercise to the reader.
 * Pruning (getting rid of less important information) is useful if language model files are too large. We can do this using `IRSTLM <https://github.com/irstlm-team/irstlm>`__:
     * Install all the IRSTLM build dependencies with ``sudo apt-get install build-essential automake autotools-dev autoconf libtool``
     * Download and extract the `IRSTLM source code <https://github.com/irstlm-team/irstlm/archive/master.zip>`__.
     * Follow the instructions in the README to install IRSTLM. Basically, run ``sh regenerate-makefiles.sh --force && ./configure && make && sudo make install`` in the IRSTLM folder.
-    * If the language model is not in ARPA format, convert it to the ARPA format. To do this, ensure that SphinxBase is installed and run ``sphinx_lm_convert -i LANGUAGE_MODEL_FILE_GOES_HERE -o language-model.lm -ofmt arpa``.
+    * If the language model is not in ARPA format, convert it to the ARPA format. To do this, ensure that SphinxBase is installed and run ``pocketsphinx_lm_convert -i LANGUAGE_MODEL_FILE_GOES_HERE -o language-model.lm -ofmt arpa``.
     * Prune the model using IRSTLM: run ``prune-lm --threshold=1e-8 t.lm pruned.lm`` to prune with a threshold of 0.00000001. The higher the threshold, the smaller the resulting file.
-    * Convert the model back into binary format if it was originally not in ARPA format. To do this, ensure that SphinxBase is installed and run ``sphinx_lm_convert -i language-model.lm -o LANGUAGE_MODEL_FILE_GOES_HERE``.
+    * Convert the model back into binary format if it was originally not in ARPA format. To do this, ensure that PocketSphinx is installed and run ``pocketsphinx_lm_convert -i language-model.lm -o LANGUAGE_MODEL_FILE_GOES_HERE``.
 * US English: ``/speech_recognition/pocketsphinx-data/en-US/`` is taken directly from the contents of `PocketSphinx's US English model <https://github.com/cmusphinx/pocketsphinx/tree/master/model/en-us>`__.
 * International French: ``/speech_recognition/pocketsphinx-data/fr-FR/``:
     * ``/speech_recognition/pocketsphinx-data/fr-FR/language-model.lm.bin`` is ``fr-small.lm.bin`` from the `Sphinx French language model <http://sourceforge.net/projects/cmusphinx/files/Acoustic%20and%20Language%20Models/French%20Language%20Model/>`__.
@@ -98,14 +90,14 @@ Notes on building the language data from source
     * ``/speech_recognition/pocketsphinx-data/fr-FR/acoustic-model/`` contains all of the files extracted from ``cmusphinx-fr-5.2.tar.gz`` in the `Sphinx French acoustic model <http://sourceforge.net/projects/cmusphinx/files/Acoustic%20and%20Language%20Models/French/>`__.
     * To get better French recognition accuracy at the expense of higher disk space and RAM usage:
         1. Download ``fr.lm.gmp`` from the `Sphinx French language model <http://sourceforge.net/projects/cmusphinx/files/Acoustic%20and%20Language%20Models/French%20Language%20Model/>`__.
-        2. Convert from DMP (an obselete Sphinx binary format) to ARPA format: ``sphinx_lm_convert -i fr.lm.gmp -o french.lm.bin``.
+        2. Convert from DMP (an obselete Sphinx binary format) to ARPA format: ``pocketsphinx_lm_convert -i fr.lm.gmp -o french.lm.bin``.
         3. Replace ``/speech_recognition/pocketsphinx-data/fr-FR/language-model.lm.bin`` with ``french.lm.bin`` created in the previous step.
 * Mandarin Chinese: ``/speech_recognition/pocketsphinx-data/zh-CN/``:
     * ``/speech_recognition/pocketsphinx-data/zh-CN/language-model.lm.bin`` is generated as follows:
         1. Download ``zh_broadcastnews_64000_utf8.DMP`` from the `Sphinx Mandarin language model <http://sourceforge.net/projects/cmusphinx/files/Acoustic%20and%20Language%20Models/Mandarin%20Language%20Model/>`__.
-        2. Convert from DMP (an obselete Sphinx binary format) to ARPA format: ``sphinx_lm_convert -i zh_broadcastnews_64000_utf8.DMP -o chinese.lm -ofmt arpa``.
+        2. Convert from DMP (an obselete Sphinx binary format) to ARPA format: ``pocketsphinx_lm_convert -i zh_broadcastnews_64000_utf8.DMP -o chinese.lm -ofmt arpa``.
         3. Prune with a threshold of 0.00000004 using ``prune-lm --threshold=4e-8 chinese.lm chinese.lm``.
-        4. Convert from ARPA format to Sphinx binary format: ``sphinx_lm_convert -i chinese.lm -o chinese.lm.bin``.
+        4. Convert from ARPA format to Sphinx binary format: ``pocketsphinx_lm_convert -i chinese.lm -o chinese.lm.bin``.
         5. Replace ``/speech_recognition/pocketsphinx-data/zh-CN/language-model.lm.bin`` with ``chinese.lm.bin`` created in the previous step.
     * ``/speech_recognition/pocketsphinx-data/zh-CN/pronounciation-dictionary.dict`` is ``zh_broadcastnews_utf8.dic`` from the `Sphinx Mandarin language model <http://sourceforge.net/projects/cmusphinx/files/Acoustic%20and%20Language%20Models/Mandarin%20Language%20Model/>`__.
     * ``/speech_recognition/pocketsphinx-data/zh-CN/acoustic-model/`` contains all of the files extracted from ``zh_broadcastnews_16k_ptm256_8000.tar.bz2`` in the `Sphinx Mandarin acoustic model <http://sourceforge.net/projects/cmusphinx/files/Acoustic%20and%20Language%20Models/Mandarin%20Broadcast%20News%20acoustic%20models/>`__.
@@ -114,7 +106,7 @@ Notes on building the language data from source
     * ``/speech_recognition/pocketsphinx-data/it-IT/language-model.lm.bin`` is generated as follows:
         1. Download ``cmusphinx-it-5.2.tar.gz`` from the `Sphinx Italian language model <https://sourceforge.net/projects/cmusphinx/files/Acoustic%20and%20Language%20Models/Italian/>`__.
         2. Extract ``/etc/voxforge_it_sphinx.lm`` from ``cmusphinx-it-5.2.tar.gz`` as ``italian.lm``.
-        3. Convert from ARPA format to Sphinx binary format: ``sphinx_lm_convert -i italian.lm -o italian.lm.bin``.
+        3. Convert from ARPA format to Sphinx binary format: ``pocketsphinx_lm_convert -i italian.lm -o italian.lm.bin``.
         4. Replace ``/speech_recognition/pocketsphinx-data/it-IT/language-model.lm.bin`` with ``italian.lm.bin`` created in the previous step.
     * ``/speech_recognition/pocketsphinx-data/it-IT/pronounciation-dictionary.dict`` is ``/etc/voxforge_it_sphinx.dic`` from ``cmusphinx-it-5.2.tar.gz`` (from the `Sphinx Italian language model <https://sourceforge.net/projects/cmusphinx/files/Acoustic%20and%20Language%20Models/Italian/>`__).
     * ``/speech_recognition/pocketsphinx-data/it-IT/acoustic-model/`` contains all of the files in ``/model_parameters`` extracted from ``cmusphinx-it-5.2.tar.gz`` (from the `Sphinx Italian language model <https://sourceforge.net/projects/cmusphinx/files/Acoustic%20and%20Language%20Models/Italian/>`__).


### PR DESCRIPTION
* Don't depend on the internal `pocketsphinx.pocketsphinx` module
* Point the documentation to the right place. **NOTE**: `--pre` is added to the `pip` command-line since PocketSphinx 5 is still pre-release, it would be good to remove it if the release happens before this is merged!