### PR TITLE
[bug] fix for python2,7, 3.3, 3.4, 3.5 support

### DIFF
--- a/speech_recognition/__init__.py
+++ b/speech_recognition/__init__.py
@@ -1510,7 +1510,7 @@ class Recognizer(AudioSource):
         if check_existing:
             # Query status.
             transciption_id = job_name
-            endpoint = f"https://api.assemblyai.com/v2/transcript/{transciption_id}"
+            endpoint = "https://api.assemblyai.com/v2/transcript/{}".format(transcription_id)
             headers = {
                 "authorization": api_token,
             }


### PR DESCRIPTION
Thank you for wonderful repository.
Current `3.9.0` drops `python2.7, 3.3, 3.4, 3.5` support, and it is caused by #434 .

`f" "` (f-strings) syntax is from `python3.6`.
https://peps.python.org/pep-0498/

As written in `setup.cfg` and `setup.py`,  this project is released for  `python2.7, 3.3, 3.4, 3.5`.
so I made this PR to support  `python2.7, 3.3, 3.4, 3.5`.

https://github.com/Uberi/speech_recognition/blob/3f4162faed237845d4dcb0cc01130fd33e715da4/setup.cfg#L4

https://github.com/Uberi/speech_recognition/blob/3f4162faed237845d4dcb0cc01130fd33e715da4/setup.py#L66-L70