### PR TITLE
Fix error when using Whisper Speech Recognition on Windows

### DIFF
--- a/speech_recognition/__init__.py
+++ b/speech_recognition/__init__.py
@@ -1691,7 +1691,34 @@ class Recognizer(AudioSource):
             self.whisper_model = getattr(self, "whisper_model", {})
             self.whisper_model[model] = whisper.load_model(model, **load_options or {})
 
-        with tempfile.NamedTemporaryFile(suffix=".wav") as f:
+        # Adapted from https://stackoverflow.com/questions/23212435/permission-denied-to-write-to-my-temporary-file
+        class CustomNamedTemporaryFile:
+            """
+            This custom implementation is needed because of the following limitation of tempfile.NamedTemporaryFile:
+
+            > Whether the name can be used to open the file a second time, while the named temporary file is still open,
+            > varies across platforms (it can be so used on Unix; it cannot on Windows NT or later).
+            """
+            def __init__(self, mode='wb', suffix = "", delete=True):
+                self._mode = mode
+                self._delete = delete
+                self.suffix=suffix
+
+            def __enter__(self):
+                # Generate a random temporary file name
+                file_name = os.path.join(tempfile.gettempdir(), os.urandom(24).hex()+self.suffix)
+                # Ensure the file is created
+                open(file_name, "x").close()
+                # Open the file in the given mode
+                self._tempFile = open(file_name, self._mode)
+                return self._tempFile
+
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                self._tempFile.close()
+                if self._delete:
+                    os.remove(self._tempFile.name)
+
+        with CustomNamedTemporaryFile(suffix=".wav") as f:
             f.write(audio_data.get_wav_data())
             f.flush()
             result = self.whisper_model[model].transcribe(


### PR DESCRIPTION
Due to Windows' limitations on temporary files, we use a custom temporary file provider to ensure Whisper TTS can work on windows. 

See https://stackoverflow.com/questions/23212435/permission-denied-to-write-to-my-temporary-file