### PR TITLE
Vosk api: allow selecting different models and automatic model download

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,8 +57,6 @@ The `library reference <https://github.com/Uberi/speech_recognition/blob/master/
 
 See `Notes on using PocketSphinx <https://github.com/Uberi/speech_recognition/blob/master/reference/pocketsphinx.rst>`__ for information about installing languages, compiling PocketSphinx, and building language packs from online resources. This document is also included under ``reference/pocketsphinx.rst``.
 
-You have to install Vosk models for using Vosk. `Here <https://alphacephei.com/vosk/models>`__ are models avaiable. You have to place them in models folder of your project, like "your-project-folder/models/your-vosk-model"
-
 Examples
 --------
 
@@ -143,9 +141,14 @@ Vosk API is **required if and only if you want to use Vosk recognizer** (``recog
 
 You can install it with ``python3 -m pip install vosk``.
 
-You also have to install Vosk Models:
+Languages can be selected with the language parameter e.g. ``recognizer_instance.recognize_vosk(language='de')``.
+Vosk will attempt to download the respective model from https://alphacephei.com/vosk/models automatically.
+Language defaults to english ``'en-us'``.
 
-`Here <https://alphacephei.com/vosk/models>`__ are models avaiable for download. You have to place them in models folder of your project, like "your-project-folder/models/your-vosk-model"
+It is possible to manually download a model and place it in a directory in your project folder.
+Reference this folder with the model parameter ``model='folder-name'``. This will take precedence over the language parameter.
+
+Models are avaiable for download `here <https://alphacephei.com/vosk/models>`__.
 
 Google Cloud Speech Library for Python (for Google Cloud Speech API users)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/speech_recognition/__init__.py
+++ b/speech_recognition/__init__.py
@@ -1684,16 +1684,31 @@ class Recognizer(AudioSource):
             return result["text"]
 
             
-    def recognize_vosk(self, audio_data, language='en'):
+    def recognize_vosk(self, audio_data, model='', language='en-us'):
         from vosk import Model, KaldiRecognizer
-        
+
         assert isinstance(audio_data, AudioData), "Data must be audio data"
-        
+
         if not hasattr(self, 'vosk_model'):
-            if not os.path.exists("model"):
-                return "Please download the model from https://github.com/alphacep/vosk-api/blob/master/doc/models.md and unpack as 'model' in the current folder."
-                exit (1)
-            self.vosk_model = Model("model")
+            if model:
+                if not os.path.exists(model):
+                    raise RequestError(f"Please download the model from https://github.com/alphacep/vosk-api/blob/master/doc/models.md and unpack as '{model}' in the current folder.")
+                self.vosk_model = Model(model)
+            else:
+                try:
+                    import requests
+                except ImportError:
+                    raise RequestError("requests module is required to download model data")
+                # verify this language is available via api
+                response = requests.get('https://alphacephei.com/vosk/models/model-list.json', timeout=10)
+                # raise error if bad response
+                response.raise_for_status()
+
+                models = response.json()
+                languages = { m["lang"] for m in models }
+                if language not in languages:
+                    raise RequestError(f"Language '{language}' not available. Available language codes are: {languages}")
+                self.vosk_model = Model(lang=language)
 
         rec = KaldiRecognizer(self.vosk_model, 16000);
         


### PR DESCRIPTION
Hello,
I added/changed two parameters in the  recognize_vosk function, which i believe to be useful.

Firstly, I added a model parameter to allow to select a model based on a model directory. This was previously hard coded to one directory named 'model', making it impossible to easily switch models respectively languages.

Secondly, I noticed that Vosk-api is actually able to download models by itself, based on a given language code. So I implemented this as another parameter 'language'. Previously there was a default language parameter provided in the function, but it was never used.

I implemented it so that the model parameter has precedence over the language parameter, but it defaults to an empty string (False). So that by default the language model is downloaded automatically, because i believe this to be more convenient for the user. However I'm aware that this breaks the previous behavior and may break a user implementation if they want to use a very specific model that they already downloaded (for example one of the larger models). If you think this is a problem i could try to change that.

Also see the updated README in the commit.

Please let me know what you think
Thanks

ps.: if this gets merged i would also update the documentation and maybe write some tests for vosk, which i think are still missing.

pss: also it may be good to actually change to return value of the vosk function to make it more in line with the other functions, since i think this is currently returning a json string, instead of a simple string like the others.