### PR TITLE
Allow prompt to be set when calling Whisper API

### DIFF
--- a/speech_recognition/recognizers/whisper.py
+++ b/speech_recognition/recognizers/whisper.py
@@ -13,6 +13,7 @@ def recognize_whisper_api(
     *,
     model: str = "whisper-1",
     api_key: str | None = None,
+    **params,
 ):
     """
     Performs speech recognition on ``audio_data`` (an ``AudioData`` instance), using the OpenAI Whisper API.
@@ -38,5 +39,5 @@ def recognize_whisper_api(
     wav_data = BytesIO(audio_data.get_wav_data())
     wav_data.name = "SpeechRecognition_audio.wav"
 
-    transcript = openai.Audio.transcribe(model, wav_data, api_key=api_key)
+    transcript = openai.Audio.transcribe(model, wav_data, api_key=api_key, **params)
     return transcript["text"]


### PR DESCRIPTION
Add a new 'params' parameter to the 'recognize_whisper_api' function, which allows the transcription prompt to be set by passing 'prompt=<string>'. This was implemented by passing the 'params' parameter to the Whisper speech recognition API.