### PR TITLE
Fixing enable_word_time_offsets

### DIFF
--- a/speech_recognition/__init__.py
+++ b/speech_recognition/__init__.py
@@ -789,7 +789,7 @@ class Recognizer(AudioSource):
                 phrases=preferred_phrases
             )]
         if show_all:
-            config['enableWordTimeOffsets'] = True  # some useful extra options for when we want all the output
+            config['enable_word_time_offsets'] = True  # some useful extra options for when we want all the output
 
         opts = {}
         if self.operation_timeout and socket.getdefaulttimeout() is None:


### PR DESCRIPTION
I got the following error when trying to use show_all with google cloud speech:

```
Traceback (most recent call last):
  File "main.py", line 47, in <module>
    sentence = r.recognize_google_cloud(audio, credentials_json=GOOGLE_CLOUD_SPEECH_CREDENTIALS,  language="de-DE", show_all=True)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/.../.../lib/python3.11/site-packages/speech_recognition/__init__.py", line 798, in recognize_google_cloud
    config = speech.RecognitionConfig(**config)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/.../.../lib/python3.11/site-packages/proto/message.py", line 565, in __init__
    raise ValueError(
ValueError: Unknown field for RecognitionConfig: enableWordTimeOffset
```

Changing the field to "enable_word_time_offsets" fixes the error and provides the word time offset for each word.