### PR TITLE
Add support for Faster Whisper

### DIFF
--- a/speech_recognition/__init__.py
+++ b/speech_recognition/__init__.py
@@ -41,7 +41,7 @@ from .exceptions import (
     UnknownValueError,
     WaitTimeoutError,
 )
-from .recognizers import whisper
+from .recognizers import whisper, fasterwhisper
 
 
 class AudioSource(object):
@@ -1502,6 +1502,7 @@ class Recognizer(AudioSource):
             return result["text"]
 
     recognize_whisper_api = whisper.recognize_whisper_api
+    recognize_faster_whisper = fasterwhisper.recognize_faster_whisper
             
     def recognize_vosk(self, audio_data, language='en'):
         from vosk import Model, KaldiRecognizer

--- a/speech_recognition/recognizers/fasterwhisper.py
+++ b/speech_recognition/recognizers/fasterwhisper.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import os
+from io import BytesIO
+
+from speech_recognition.audio import AudioData
+from speech_recognition.exceptions import SetupError
+
+
+def recognize_faster_whisper(
+    recognizer,
+    audio_data: "AudioData",
+    model="base",
+    beam_size=5,
+    device="auto",
+    compute_type="int8",
+    show_dict=False,
+    language=None,
+    translate=False,
+    **transcribe_options
+):
+    """
+    Performs speech recognition on ``audio_data`` (an ``AudioData`` instance), using the Faster Whisper implementation of OpenAI Whisper.
+
+    Detail: https://github.com/guillaumekln/faster-whisper
+
+    Most options are identical to the original Whisper function. New options are:
+
+    {beam_size}: Allows overriding the default beam size if desired.
+    {device}: Allows setting the device, e.g. "auto", "cpu", "cuda", etc.
+    {compute_type}: Allows setting the compute type, e.g. "int8", "float16", etc.
+
+    The return dict is also customized to avoid returning a mess of FasterWhisper objects.
+    """
+
+    assert isinstance(audio_data, AudioData), "Data must be audio data"
+
+    import numpy as np
+    import soundfile as sf
+    import faster_whisper
+
+    print(f"model: {model}, beam_size: {beam_size}, device: {device}, compute_type: {compute_type}, language: {language}, translate: {translate}")
+
+    whisper_model = faster_whisper.WhisperModel(model, device=device, compute_type=compute_type)
+
+    # 16 kHz https://github.com/openai/whisper/blob/28769fcfe50755a817ab922a7bc83483159600a9/whisper/audio.py#L98-L99
+    wav_bytes = audio_data.get_wav_data(convert_rate=16000)
+    wav_stream = BytesIO(wav_bytes)
+    audio_array, sampling_rate = sf.read(wav_stream)
+    audio_array = audio_array.astype(np.float32)
+
+    segments, info = whisper_model.transcribe(
+        audio_array,
+        beam_size=beam_size,
+        language=language,
+        task="translate" if translate else None,
+        **transcribe_options
+    )
+    found_text = list()
+    for segment in segments:
+        found_text.append(segment.text)
+    text = ' '.join(found_text).strip()
+
+    if show_dict:
+        result = {
+            "text": text,
+            "language": info.language,
+            "language_probability": info.language_probability,
+            "duration": info.duration,
+        }
+    else:
+        result = text
+
+    return result

--- a/speech_recognition/recognizers/fasterwhisper.py
+++ b/speech_recognition/recognizers/fasterwhisper.py
@@ -11,6 +11,7 @@ def recognize_faster_whisper(
     recognizer,
     audio_data: "AudioData",
     model="base",
+    download_root=None,
     beam_size=5,
     device="auto",
     compute_type="int8",
@@ -29,6 +30,7 @@ def recognize_faster_whisper(
     {beam_size}: Allows overriding the default beam size if desired.
     {device}: Allows setting the device, e.g. "auto", "cpu", "cuda", etc.
     {compute_type}: Allows setting the compute type, e.g. "int8", "float16", etc.
+    {download_root}: Allows setting the model cache root path
 
     The return dict is also customized to avoid returning a mess of FasterWhisper objects.
     """
@@ -39,9 +41,9 @@ def recognize_faster_whisper(
     import soundfile as sf
     import faster_whisper
 
-    print(f"model: {model}, beam_size: {beam_size}, device: {device}, compute_type: {compute_type}, language: {language}, translate: {translate}")
+    print(f"model: {model}, download_root: {download_root}, beam_size: {beam_size}, device: {device}, compute_type: {compute_type}, language: {language}, translate: {translate}")
 
-    whisper_model = faster_whisper.WhisperModel(model, device=device, compute_type=compute_type)
+    whisper_model = faster_whisper.WhisperModel(model, device=device, compute_type=compute_type, download_root=download_root)
 
     # 16 kHz https://github.com/openai/whisper/blob/28769fcfe50755a817ab922a7bc83483159600a9/whisper/audio.py#L98-L99
     wav_bytes = audio_data.get_wav_data(convert_rate=16000)

--- a/tests/test_recognition.py
+++ b/tests/test_recognition.py
@@ -100,17 +100,17 @@ class TestRecognition(unittest.TestCase):
     def test_faster_whisper_english(self):
         r = sr.Recognizer()
         with sr.AudioFile(self.AUDIO_FILE_EN) as source: audio = r.record(source)
-        self.assertEqual(r.recognize_faster_whisper(audio, language="english", **self.WHISPER_CONFIG), " 1, 2, 3.")
+        self.assertEqual(r.recognize_faster_whisper(audio, device="cpu", language="en"), "1, 2, 3.")
 
     def test_faster_whisper_french(self):
         r = sr.Recognizer()
         with sr.AudioFile(self.AUDIO_FILE_FR) as source: audio = r.record(source)
-        self.assertEqual(r.recognize_faster_whisper(audio, language="french", **self.WHISPER_CONFIG), " et c'est la dictée numéro 1.")
+        self.assertEqual(r.recognize_faster_whisper(audio, device="cpu", language="fr"), "et c'est la dictée numéro 1.")
 
     def test_faster_whisper_chinese(self):
         r = sr.Recognizer()
         with sr.AudioFile(self.AUDIO_FILE_ZH) as source: audio = r.record(source)
-        self.assertEqual(r.recognize_faster_whisper(audio, model="small", language="chinese", **self.WHISPER_CONFIG), u"砸自己的腳")
+        self.assertEqual(r.recognize_faster_whisper(audio, device="cpu", model="small", language="zh"), u"砸自己的脚")
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_recognition.py
+++ b/tests/test_recognition.py
@@ -97,5 +97,20 @@ class TestRecognition(unittest.TestCase):
         with sr.AudioFile(self.AUDIO_FILE_ZH) as source: audio = r.record(source)
         self.assertEqual(r.recognize_whisper(audio, model="small", language="chinese", **self.WHISPER_CONFIG), u"砸自己的腳")
 
+    def test_faster_whisper_english(self):
+        r = sr.Recognizer()
+        with sr.AudioFile(self.AUDIO_FILE_EN) as source: audio = r.record(source)
+        self.assertEqual(r.recognize_faster_whisper(audio, language="english", **self.WHISPER_CONFIG), " 1, 2, 3.")
+
+    def test_faster_whisper_french(self):
+        r = sr.Recognizer()
+        with sr.AudioFile(self.AUDIO_FILE_FR) as source: audio = r.record(source)
+        self.assertEqual(r.recognize_faster_whisper(audio, language="french", **self.WHISPER_CONFIG), " et c'est la dictée numéro 1.")
+
+    def test_faster_whisper_chinese(self):
+        r = sr.Recognizer()
+        with sr.AudioFile(self.AUDIO_FILE_ZH) as source: audio = r.record(source)
+        self.assertEqual(r.recognize_faster_whisper(audio, model="small", language="chinese", **self.WHISPER_CONFIG), u"砸自己的腳")
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The Faster Whisper library purports to be significantly faster than the original OpenAI Whisper library, so add support for it as well.

It is, unfortunately, not completely identical so we need this new module to support it. That said 90% of it is still the same as the original whisper, so most of that was just copied from the existing function in `__init__.py`.

Note that I found in testing, that on a Pi4 with a decent SD card, importing the "torch" library took upwards of 4 seconds, wasting valuable time just to detect CUDA support. So instead of trying to do this here, I added several configurable parameters from upstream to set CUDA, etc. support if the user wants it. It will default to "auto" mode and defer this to faster_whisper itself unless set.

The print statement is there for debugging to confirm the sent options, but I don't see any sort of logger or printing inside this library. It can be removed if desired.

While testing this change, I found a major memory leak caused somehow by faster_whisper here; each run of this function would balloon memory usage in the parent process by anywhere from 10 to 100MB and quickly result in an OOM. Despite several attempts I wasn't able to get the Python garbage collector to free this memory, so I decided instead to move the actual work to a multiprocessing (sub)Process so that it would truly be freed after each run. The result is passed back via a multiprocessing Queue. This seems to completely solve the memory leak and does not seem to harm performance or functionality.