### PR TITLE
bugfix: not able to use options "show_all" and "preferred_phrases"

### DIFF
--- a/speech_recognition/__init__.py
+++ b/speech_recognition/__init__.py
@@ -785,11 +785,11 @@ class Recognizer(AudioSource):
             'language_code': language
         }
         if preferred_phrases is not None:
-            config['speechContexts'] = [speech.SpeechContext(
+            config['speech_contexts'] = [speech.SpeechContext(
                 phrases=preferred_phrases
             )]
         if show_all:
-            config['enableWordTimeOffsets'] = True  # some useful extra options for when we want all the output
+            config['enable_word_time_offsets'] = True  # some useful extra options for when we want all the output
 
         opts = {}
         if self.operation_timeout and socket.getdefaulttimeout() is None:


### PR DESCRIPTION
I was not able to use the options "show_all" and "preferred_phrases" when using recognize_google_cloud.

I got the following errors:
```
Unknown field for RecognitionConfig: enableWordTimeOffsets
```
and 

```
Unknown field for RecognitionConfig: speechContexts
```

I found that the issue was a wrong integration with the google cloud API where camelCasing was used and not the python snake_casing convention as defined in the [Google Cloud Python Documentation](https://cloud.google.com/python/docs/reference/speech/latest/google.cloud.speech_v1.types.RecognitionConfig).

After manually making these changes I was able to use both options successfully. 