### PR TITLE
Updated to the latest OpenAI API changes, and fixed #720

### DIFF
--- a/speech_recognition/recognizers/whisper.py
+++ b/speech_recognition/recognizers/whisper.py
@@ -29,7 +29,7 @@ def recognize_whisper_api(
         raise SetupError("Set environment variable ``OPENAI_API_KEY``")
 
     try:
-        import openai
+        from openai import OpenAI
     except ImportError:
         raise SetupError(
             "missing openai module: ensure that openai is set up correctly."
@@ -38,5 +38,9 @@ def recognize_whisper_api(
     wav_data = BytesIO(audio_data.get_wav_data())
     wav_data.name = "SpeechRecognition_audio.wav"
 
-    transcript = openai.Audio.transcribe(model, wav_data, api_key=api_key)
-    return transcript["text"]
+    openai = OpenAI(api_key=api_key)
+    transcript = openai.audio.transcriptions.create(
+        file=wav_data, model=model
+    )
+    
+    return transcript.text

--- a/speech_recognition/recognizers/whisper.py
+++ b/speech_recognition/recognizers/whisper.py
@@ -29,7 +29,7 @@ def recognize_whisper_api(
         raise SetupError("Set environment variable ``OPENAI_API_KEY``")
 
     try:
-        from openai import OpenAI
+        import openai
     except ImportError:
         raise SetupError(
             "missing openai module: ensure that openai is set up correctly."
@@ -38,9 +38,6 @@ def recognize_whisper_api(
     wav_data = BytesIO(audio_data.get_wav_data())
     wav_data.name = "SpeechRecognition_audio.wav"
 
-    openai = OpenAI(api_key=api_key)
-    transcript = openai.audio.transcriptions.create(
-        file=wav_data, model=model
-    )
-    
+    client = openai.OpenAI(api_key=api_key)
+    transcript = client.audio.transcriptions.create(file=wav_data, model=model)
     return transcript.text

--- a/tests/test_recognition.py
+++ b/tests/test_recognition.py
@@ -84,7 +84,7 @@ class TestRecognition(unittest.TestCase):
     def test_whisper_english(self):
         r = sr.Recognizer()
         with sr.AudioFile(self.AUDIO_FILE_EN) as source: audio = r.record(source)
-        self.assertEqual(r.recognize_whisper(audio, language="english", **self.WHISPER_CONFIG), " 1, 2, 3.")
+        self.assertEqual(r.recognize_whisper(audio, language="english", **self.WHISPER_CONFIG), " 1, 2, 3")
 
     def test_whisper_french(self):
         r = sr.Recognizer()


### PR DESCRIPTION
In November OpenAI released version 1.0 that deprecated a lot of old API.

These changes addresses issues raised in #720 and fixes now completely broken `recognize_whisper_api` API.