### PR TITLE
Fix: modify `recognize_whisper_api` according to the new version of the OpenAI API

### DIFF
--- a/speech_recognition/recognizers/whisper.py
+++ b/speech_recognition/recognizers/whisper.py
@@ -38,5 +38,6 @@ def recognize_whisper_api(
     wav_data = BytesIO(audio_data.get_wav_data())
     wav_data.name = "SpeechRecognition_audio.wav"
 
-    transcript = openai.Audio.transcribe(model, wav_data, api_key=api_key)
-    return transcript["text"]
+    client=openai.OpenAI(api_key=api_key)
+    transcript = client.audio.transcriptions.create(model=model, file=wav_data)
+    return transcript.text


### PR DESCRIPTION
This PR addresses the deprecation of the `audio.transcribe` endpoint, which is no longer functional. The updated code now utilizes the `audio.transcriptions.create` endpoint for speech recognition tasks. This change involves the creation of a new client to interact with the updated endpoint, ensuring the continued functionality of our audio transcription services.