### PR TITLE
Add flush_flag to listener to flush the recorded audio immediately without waiting for the phrase to complete.

### DIFF
--- a/speech_recognition/__init__.py
+++ b/speech_recognition/__init__.py
@@ -447,7 +447,7 @@ class Recognizer(AudioSource):
 
         return b"".join(frames), elapsed_time
 
-    def listen(self, source, timeout=None, phrase_time_limit=None, snowboy_configuration=None):
+    def listen(self, source, timeout=None, phrase_time_limit=None, snowboy_configuration=None, flush_flag=[False]):
         """
         Records a single phrase from ``source`` (an ``AudioSource`` instance) into an ``AudioData`` instance, which it returns.
 
@@ -515,6 +515,11 @@ class Recognizer(AudioSource):
             pause_count, phrase_count = 0, 0
             phrase_start_time = elapsed_time
             while True:
+                if(flush_flag[0]):
+                    flush_flag[0] = False
+                    buffer == b''
+                    break
+                
                 # handle phrase being too long by cutting off the audio
                 elapsed_time += seconds_per_buffer
                 if phrase_time_limit and elapsed_time - phrase_start_time > phrase_time_limit:
@@ -544,7 +549,7 @@ class Recognizer(AudioSource):
 
         return AudioData(frame_data, source.SAMPLE_RATE, source.SAMPLE_WIDTH)
 
-    def listen_in_background(self, source, callback, phrase_time_limit=None):
+    def listen_in_background(self, source, callback, flush_flag, phrase_time_limit=None):
         """
         Spawns a thread to repeatedly record phrases from ``source`` (an ``AudioSource`` instance) into an ``AudioData`` instance and call ``callback`` with that ``AudioData`` instance as soon as each phrase are detected.
 
@@ -561,7 +566,7 @@ class Recognizer(AudioSource):
             with source as s:
                 while running[0]:
                     try:  # listen for 1 second, then check again if the stop function has been called
-                        audio = self.listen(s, 1, phrase_time_limit)
+                        audio = self.listen(s, 1, phrase_time_limit, flush_flag=flush_flag)
                     except WaitTimeoutError:  # listening timed out, just try again
                         pass
                     else:


### PR DESCRIPTION
Add flush_flag to listener to flush the recorded audio immediately without waiting for the phrase to complete.

I am working on a real time speech to text application where I am kinda facing an issue.
When the user is done talking, the speech_recognizer waits until the pause_threshold is elapsed. This gets even worse in noisy environments with the dynamic_energy_threshold turned off.

My users don't want to wait as they know that they are done talking. They want to be able to hit enter and reduce the time taken to show them the transcription.

This is just one example of where this could be helpful. I'm sure this feature can be useful in many ways.

I have tried `stopper` but, it takes a maximum of a second to stop but wont flush the audio.
Also, the stopper wont stop the recorder when the audio is being actively recorded at the times where `energy > energy_threshold`.

Hence this change.

How to use?

```
self.flush_flag = [False]
self.recorder.listen_in_background(self.source, self.record_callback, phrase_time_limit=self.record_timeout, flush_flag=self.flush_flag)
        
def onEnter():
    self.flush_flag = [True] # this flag will be reset to false once the audio is flushed.
```

Please feel free to modify the logic to make it more clean and robust.
TIA.
<|endoftext|>