### PR TITLE
Add whisper test cases #776

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,6 @@ pocketsphinx-python/
 examples/TEST.py
 *.geany
 *.out
+
+#vscode
+.vscode/

--- a/tests/recognizers/test_whisper.py
+++ b/tests/recognizers/test_whisper.py
@@ -2,13 +2,13 @@ from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
 from speech_recognition import AudioData, Recognizer
+from speech_recognition.exceptions import SetupError
 from speech_recognition.recognizers import whisper
 
-
-@patch("speech_recognition.recognizers.whisper.os.environ")
-@patch("speech_recognition.recognizers.whisper.BytesIO")
-@patch("openai.OpenAI")
 class RecognizeWhisperApiTestCase(TestCase):
+    @patch("speech_recognition.recognizers.whisper.os.environ")
+    @patch("speech_recognition.recognizers.whisper.BytesIO")
+    @patch("openai.OpenAI")
     def test_recognize_default_arguments(self, OpenAI, BytesIO, environ):
         client = OpenAI.return_value
         transcript = client.audio.transcriptions.create.return_value
@@ -26,6 +26,9 @@ class RecognizeWhisperApiTestCase(TestCase):
             file=BytesIO.return_value, model="whisper-1"
         )
 
+    @patch("speech_recognition.recognizers.whisper.os.environ")
+    @patch("speech_recognition.recognizers.whisper.BytesIO")
+    @patch("openai.OpenAI")
     def test_recognize_pass_arguments(self, OpenAI, BytesIO, environ):
         client = OpenAI.return_value
 
@@ -39,4 +42,63 @@ class RecognizeWhisperApiTestCase(TestCase):
         OpenAI.assert_called_once_with(api_key="OPENAI_API_KEY")
         client.audio.transcriptions.create.assert_called_once_with(
             file=BytesIO.return_value, model="x-whisper"
+        )
+
+    # Test case to verify that ValueError is raised for invalid audio data
+    # Mocking the os.environ to control environment variables
+    @patch("speech_recognition.recognizers.whisper.os.environ")
+    # Mocking BytesIO for handling byte streams
+    @patch("speech_recognition.recognizers.whisper.BytesIO")
+    # Mocking the OpenAI API client
+    @patch("openai.OpenAI")
+    def test_value_error_invalid_audio_data(self, OpenAI, BytesIO, environ):
+        # Create a mock client for OpenAI
+        client = OpenAI.return_value
+        
+        # Create a mock Recognizer instance
+        recognizer = MagicMock(spec=Recognizer)  
+        # Define invalid audio data
+        invalid_audio_data = "invalid data"
+        
+        # Assert that ValueError is raised when invalid audio data is passed
+        with self.assertRaises(ValueError) as context:
+            whisper.recognize_whisper_api(recognizer, invalid_audio_data)
+        # Check that the exception message is as expected
+        self.assertEqual(str(context.exception), "``audio_data`` must be an ``AudioData`` instance")
+
+    # Test case to verify that SetupError is raised when API key is missing
+    def test_missing_api_key(self):
+        # Create a mock Recognizer instance
+        recognizer = MagicMock(spec=Recognizer)
+        # Create a mock AudioData instance
+        audio_data = MagicMock(spec=AudioData)
+
+        # Assert that SetupError is raised when no API key is provided
+        with self.assertRaises(SetupError) as context:
+            whisper.recognize_whisper_api(recognizer, audio_data, model="x-whisper", api_key=None)
+        
+        # Check that the exception message indicates the API key is not set
+        self.assertEqual(str(context.exception), "Set environment variable ``OPENAI_API_KEY``")
+    
+    # Test case to verify that SetupError is raised when the OpenAI module is not found
+    # Mocking the os.environ
+    @patch("speech_recognition.recognizers.whisper.os.environ")
+    # Mocking BytesIO
+    @patch("speech_recognition.recognizers.whisper.BytesIO")
+    # Simulate that the OpenAI module is not available
+    @patch.dict("sys.modules", {"openai": None})
+    def test_import_error_openai(self, BytesIO, environ):
+        # Create a mock Recognizer instance
+        recognizer = MagicMock(spec=Recognizer)
+        # Create a mock AudioData instance
+        audio_data = MagicMock(spec=AudioData)
+
+        # Assert that SetupError is raised when OpenAI module is missing
+        with self.assertRaises(SetupError) as context:
+            whisper.recognize_whisper_api(recognizer, audio_data)
+
+        # Check that the exception message indicates the missing OpenAI module
+        self.assertEqual(
+            str(context.exception),
+            "missing openai module: ensure that openai is set up correctly."
         )


### PR DESCRIPTION
Test cases for whisper recognizer:
Raise a SetupError when the API key is missing.
Raise a ValueError when invalid audio data is provided.
Raise a SetupError with a specific error message when the openai module is not found.