### PR TITLE
Clarify the dead batteries workaround for Python >= 3.13

### DIFF
--- a/speech_recognition/__init__.py
+++ b/speech_recognition/__init__.py
@@ -4,8 +4,11 @@
 
 from __future__ import annotations
 
-import aifc
-import audioop
+try:
+    import aifc
+    import audioop
+except ModuleNotFoundError:
+    raise ModuleNotFoundError("Please run: pip install audioop-lts standard-aifc")
 import base64
 import collections
 import hashlib


### PR DESCRIPTION
```
try:
    import aifc
    import audioop
except ModuleNotFoundError as e:
    raise ModuleNotFoundError("Please run: pip install audioop-lts standard-aifc") from e
```
https://docs.python.org/3.13/whatsnew/3.13.html#whatsnew313-pep594

```bash
python3.13 -m venv .venv
source .venv/bin/activate
python -m pip install --upgrade pip
pip install git+https://github.com/Uberi/speech_recognition.git

        File "/private/var/folders/2n/pb5cf4g10kdfvw9yvsfxy4gr0000gn/T/pip-req-build-uiogiiny/speech_recognition/__init__.py", line 7, in <module>
          import aifc
      ModuleNotFoundError: No module named 'aifc'
 
× Getting requirements to build wheel did not run successfully.
│ exit code: 1
```