### PR TITLE
chore: Make copyright year of license not need to update

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2014-2017, Anthony Zhang <azhang9@gmail.com>
+Copyright (c) 2014-, Anthony Zhang <azhang9@gmail.com>
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/README.rst
+++ b/README.rst
@@ -400,7 +400,7 @@ Also check out the `Python Baidu Yuyin API <https://github.com/DelightRun/PyBaid
 License
 -------
 
-Copyright 2014-2017 `Anthony Zhang (Uberi) <http://anthonyz.ca/>`__. The source code for this library is available online at `GitHub <https://github.com/Uberi/speech_recognition>`__.
+Copyright 2014- `Anthony Zhang (Uberi) <http://anthonyz.ca/>`__. The source code for this library is available online at `GitHub <https://github.com/Uberi/speech_recognition>`__.
 
 SpeechRecognition is made available under the 3-clause BSD license. See ``LICENSE.txt`` in the project's `root directory <https://github.com/Uberi/speech_recognition>`__ for more information.
 


### PR DESCRIPTION
Fix https://github.com/Uberi/speech_recognition/pull/816 (Deleted. "Update LICENSE.txt, fix copyright license year")

ref(Japanese): https://zenn.dev/dalance/articles/7ecaf9369324c1#%E5%B9%B4%E5%BA%A6%E3%82%92%E6%9B%B4%E6%96%B0%E3%81%99%E3%81%B9%E3%81%8D%E3%81%AA%E3%81%AE%E3%81%8B