### PR TITLE
Recognizer Google Cloud Load Credentials from JSON Dictionary

### DIFF
--- a/speech_recognition/recognizers/google_cloud.py
+++ b/speech_recognition/recognizers/google_cloud.py
@@ -82,12 +82,13 @@ def recognize(
     recognizer,
     audio_data: AudioData,
     credentials_json_path: str | None = None,
+    credentials_json: dict | None = None,
     **kwargs: GoogleCloudRecognizerParameters,
 ) -> str | RecognizeResponse:
     """Performs speech recognition on ``audio_data`` (an ``AudioData`` instance), using the Google Cloud Speech-to-Text V1 API.
 
     This function requires a Google Cloud Platform account; see the `Set up Speech-to-Text <https://cloud.google.com/speech-to-text/docs/before-you-begin>`__ for details and instructions. Basically, create a project, enable billing for the project, enable the Google Cloud Speech API for the project.
-    And create local authentication credentials for your user account. The result is a JSON file containing the API credentials. You can specify the JSON file by ``credentials_json_path``. If not specified, the library will try to automatically `find the default API credentials JSON file <https://developers.google.com/identity/protocols/application-default-credentials>`__.
+    And create local authentication credentials for your user account. The result is a JSON file containing the API credentials. You can specify the JSON file by ``credentials_json_path`` or JSON dictionary by ``credentials_json``. If not specified, the library will try to automatically `find the default API credentials JSON file <https://developers.google.com/identity/protocols/application-default-credentials>`__.
 
     Returns the most likely transcription if ``show_all`` is False (the default). Otherwise, returns the raw API response as a JSON dictionary.
     For other parameters, see :py:class:`GoogleCloudRecognizerParameters`.
@@ -105,6 +106,8 @@ def recognize(
     client = (
         speech.SpeechClient.from_service_account_json(credentials_json_path)
         if credentials_json_path
+        else speech.SpeechClient.from_service_account_info(credentials_json)
+        if credentials_json
         else speech.SpeechClient()
     )
 

--- a/tests/recognizers/test_google_cloud.py
+++ b/tests/recognizers/test_google_cloud.py
@@ -81,6 +81,58 @@ def test_transcribe_with_specified_credentials(SpeechClient):
 
 
 @patch("google.cloud.speech.SpeechClient")
+def test_transcribe_with_specified_credentials_json(SpeechClient):
+    client = SpeechClient.from_service_account_info.return_value
+    client.recognize.return_value = RecognizeResponse(
+        results=[
+            SpeechRecognitionResult(
+                alternatives=[
+                    SpeechRecognitionAlternative(
+                        transcript="transcript", confidence=0.9
+                    )
+                ]
+            )
+        ]
+    )
+
+    audio_data = MagicMock(spec=AudioData)
+    audio_data.sample_rate = 16_000
+    audio_data.get_flac_data.return_value = b"flac_data"
+
+    _ = recognize(
+        MagicMock(spec=Recognizer),
+        audio_data,
+        credentials_json={
+            "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+            "client_email": "",
+            "client_id": "",
+            "client_x509_cert_url": "",
+            "private_key": "",
+            "private_key_id": "",
+            "project_id": "",
+            "token_uri": "https://oauth2.googleapis.com/token",
+            "type": "service_account"
+        },
+    )
+
+    SpeechClient.from_service_account_info.assert_called_once_with(
+        {
+            "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+            "client_email": "",
+            "client_id": "",
+            "client_x509_cert_url": "",
+            "private_key": "",
+            "private_key_id": "",
+            "project_id": "",
+            "token_uri": "https://oauth2.googleapis.com/token",
+            "type": "service_account"
+        }
+    )
+
+
+@patch("google.cloud.speech.SpeechClient")
 def test_transcribe_show_all(SpeechClient):
     client = SpeechClient.return_value
     client.recognize.return_value = RecognizeResponse(


### PR DESCRIPTION
This change allows credentials to be passed to the Google Cloud recognizer via a JSON dictionary instead of just a JSON file.
This is useful in certain production environments.