### PR TITLE
Restore local Whisper test coverage on Python 3.13

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -45,12 +45,12 @@ jobs:
           sudo apt-get install --no-install-recommends -y portaudio19-dev
       - name: Install ffmpeg (for Whisper)
         uses: FedericoCarboni/setup-ffmpeg@37062fbf7149fc5578d6c57e08aed62458b375d6 # v3.1
-      - name: Install Python dependencies (Ubuntu, <=3.12)
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version != '3.13' && matrix.python-version != '3.14'
+      - name: Install Python dependencies (Ubuntu, <=3.13)
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version != '3.14'
         run: |
           python -m pip install .[dev,audio,pocketsphinx,google-cloud,whisper-local,faster-whisper,openai,groq,vosk,cohere-api]
-      - name: Install Python dependencies (Ubuntu, >=3.13)
-        if: matrix.os == 'ubuntu-latest' && (matrix.python-version == '3.13' || matrix.python-version == '3.14')
+      - name: Install Python dependencies (Ubuntu, 3.14)
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.14'
         run: |
           python -m pip install .[dev,audio,pocketsphinx,google-cloud,openai,groq,vosk,cohere-api]
       - name: Install Python dependencies (Windows)

--- a/tests/recognizers/whisper_local/test_faster_whisper.py
+++ b/tests/recognizers/whisper_local/test_faster_whisper.py
@@ -52,7 +52,7 @@ def soundfile_read() -> Generator[tuple[MagicMock, np.ndarray], None, None]:
 
 
 @pytest.mark.skipif(
-    sys.version_info >= (3, 13), reason="skip on Python 3.13 or later"
+    sys.version_info >= (3, 14), reason="skip on Python 3.14 or later"
 )
 @patch("faster_whisper.WhisperModel")
 class TestTranscribe:

--- a/tests/recognizers/whisper_local/test_whisper.py
+++ b/tests/recognizers/whisper_local/test_whisper.py
@@ -8,7 +8,7 @@ from speech_recognition import AudioData, Recognizer
 from speech_recognition.recognizers.whisper_local.whisper import recognize
 
 
-@skipIf(sys.version_info >= (3, 13), "skip on Python 3.13")
+@skipIf(sys.version_info >= (3, 14), "skip on Python 3.14")
 @patch("soundfile.read")
 @patch("torch.cuda.is_available")
 @patch("whisper.load_model")


### PR DESCRIPTION
## Summary
Restore the local Whisper test coverage on Python 3.13.

This change:
- runs the whisper-local and faster-whisper dependency set again on Ubuntu for Python 3.13
- updates the local Whisper test skips so they are skipped only on Python 3.14 and later
- keeps the lighter dependency set for Python 3.14 unchanged

## Verification
- python3 -m py_compile tests/recognizers/whisper_local/test_whisper.py tests/recognizers/whisper_local/test_faster_whisper.py
- git diff --check
- pytest -q tests/recognizers/whisper_local/test_whisper.py tests/recognizers/whisper_local/test_faster_whisper.py in the local Python 3.14 environment stopped at collection because numpy was not installed
