### PR TITLE
Comment out Python 3.14 classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,8 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
-  "Programming Language :: Python :: 3.14",
+  # "Programming Language :: Python :: 3.14",
+  # openai-whisper does not support Python 3.14 yet.
   "Topic :: Software Development :: Libraries :: Python Modules",
   "Topic :: Multimedia :: Sound/Audio :: Speech",
 ]


### PR DESCRIPTION
## Summary
- comment out the Python 3.14 classifier in 
- keep the change limited to package metadata
- note that  does not support Python 3.14 yet
