### PR TITLE
Add isolated CI coverage for extras and guard optional-dependency tests

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -9,7 +9,27 @@ on:
       - master
 
 jobs:
-  build:
+  base:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Set up Python 3.11
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.11"
+      - name: Create virtual environment
+        run: python -m venv .venv
+      - name: Install base test dependencies
+        run: |
+          . .venv/bin/activate
+          python -m pip install --upgrade pip
+          python -m pip install .[dev]
+      - name: Test base installation
+        run: |
+          . .venv/bin/activate
+          pytest -s -v tests/
+
+  all-extras:
     strategy:
       fail-fast: true
       matrix:
@@ -59,6 +79,73 @@ jobs:
           python -m pip install .[dev,whisper-local,faster-whisper,google-cloud,openai,groq,vosk,cohere-api]
       - name: Set up vosk model
         run: python -m speech_recognition.cli download vosk
-      - name: Test with unittest
+      - name: Test with pytest
         run: |
           pytest --doctest-modules -s -v speech_recognition/recognizers/ tests/
+
+  extra-contracts:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - extra: audio
+            install-spec: .[dev,audio]
+            verify-command: python -c "from speech_recognition import Microphone; Microphone.get_pyaudio()"
+          - extra: pocketsphinx
+            install-spec: .[dev,pocketsphinx]
+            verify-command: pytest -s -v tests/test_recognition.py tests/test_special_features.py
+          - extra: google-cloud
+            install-spec: .[dev,google-cloud]
+            verify-command: pytest -s -v tests/recognizers/test_google_cloud.py
+          - extra: whisper-local
+            install-spec: .[dev,whisper-local]
+            verify-command: pytest -s -v tests/recognizers/whisper_local/test_whisper.py
+          - extra: faster-whisper
+            install-spec: .[dev,faster-whisper]
+            verify-command: pytest -s -v tests/recognizers/whisper_local/test_faster_whisper.py
+          - extra: openai
+            install-spec: .[dev,openai]
+            verify-command: pytest -s -v tests/recognizers/whisper_api/test_openai.py tests/recognizers/whisper_api/test_openai_compatible.py
+          - extra: groq
+            install-spec: .[dev,groq]
+            verify-command: pytest -s -v tests/recognizers/whisper_api/test_groq.py
+          - extra: cohere-api
+            install-spec: .[dev,cohere-api]
+            verify-command: pytest -s -v tests/recognizers/test_cohere_api.py
+          - extra: assemblyai
+            install-spec: .[dev,assemblyai]
+            verify-command: python -c "from speech_recognition import Recognizer; assert hasattr(Recognizer(), 'recognize_assemblyai')"
+          - extra: vosk
+            install-spec: .[dev,vosk]
+            setup-vosk-model: true
+            verify-command: pytest -s -v tests/recognizers/test_vosk.py
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Set up Python 3.11
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.11"
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          # For pocketsphinx (already installed: swig)
+          sudo apt-get install --no-install-recommends -y libpulse-dev libasound2-dev
+          # For PyAudio
+          sudo apt-get install --no-install-recommends -y portaudio19-dev
+      - name: Create virtual environment
+        run: python -m venv .venv
+      - name: Install extra dependencies
+        run: |
+          . .venv/bin/activate
+          python -m pip install --upgrade pip
+          python -m pip install ${{ matrix.install-spec }}
+      - name: Set up vosk model
+        if: matrix.setup-vosk-model == true
+        run: |
+          . .venv/bin/activate
+          python -m speech_recognition.cli download vosk
+      - name: Verify ${{ matrix.extra }} extra
+        run: |
+          . .venv/bin/activate
+          ${{ matrix.verify-command }}

--- a/tests/recognizers/test_cohere_api.py
+++ b/tests/recognizers/test_cohere_api.py
@@ -1,7 +1,11 @@
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from speech_recognition import AudioData, Recognizer
 from speech_recognition.recognizers import cohere_api
+
+pytest.importorskip("cohere")
 
 
 @patch("cohere.ClientV2")

--- a/tests/recognizers/test_google_cloud.py
+++ b/tests/recognizers/test_google_cloud.py
@@ -2,21 +2,19 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-pytest.importorskip("google.cloud.speech")
-
-from google.cloud.speech import (
-    RecognitionAudio,
-    RecognitionConfig,
-    RecognizeResponse,
-    SpeechContext,
-    SpeechRecognitionAlternative,
-    SpeechRecognitionResult,
-    WordInfo,
-)
-
 from speech_recognition import Recognizer
 from speech_recognition.audio import AudioData
 from speech_recognition.recognizers.google_cloud import recognize
+
+speech = pytest.importorskip("google.cloud.speech")
+
+RecognitionAudio = speech.RecognitionAudio
+RecognitionConfig = speech.RecognitionConfig
+RecognizeResponse = speech.RecognizeResponse
+SpeechContext = speech.SpeechContext
+SpeechRecognitionAlternative = speech.SpeechRecognitionAlternative
+SpeechRecognitionResult = speech.SpeechRecognitionResult
+WordInfo = speech.WordInfo
 
 
 @patch("google.cloud.speech.SpeechClient")

--- a/tests/recognizers/test_google_cloud.py
+++ b/tests/recognizers/test_google_cloud.py
@@ -1,5 +1,9 @@
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+pytest.importorskip("google.cloud.speech")
+
 from google.cloud.speech import (
     RecognitionAudio,
     RecognitionConfig,

--- a/tests/recognizers/test_vosk.py
+++ b/tests/recognizers/test_vosk.py
@@ -2,6 +2,8 @@ from pathlib import Path
 
 import pytest
 
+pytest.importorskip("vosk")
+
 from speech_recognition import AudioData, Recognizer
 
 

--- a/tests/recognizers/test_vosk.py
+++ b/tests/recognizers/test_vosk.py
@@ -2,9 +2,9 @@ from pathlib import Path
 
 import pytest
 
-pytest.importorskip("vosk")
-
 from speech_recognition import AudioData, Recognizer
+
+pytest.importorskip("vosk")
 
 
 @pytest.fixture

--- a/tests/recognizers/whisper_api/test_groq.py
+++ b/tests/recognizers/whisper_api/test_groq.py
@@ -4,10 +4,10 @@ import httpx
 import pytest
 import respx
 
-pytest.importorskip("groq")
-
 from speech_recognition import AudioData, Recognizer
 from speech_recognition.recognizers.whisper_api import groq
+
+pytest.importorskip("groq")
 
 
 @respx.mock(assert_all_called=True, assert_all_mocked=True)

--- a/tests/recognizers/whisper_api/test_groq.py
+++ b/tests/recognizers/whisper_api/test_groq.py
@@ -1,7 +1,10 @@
 from unittest.mock import MagicMock
 
 import httpx
+import pytest
 import respx
+
+pytest.importorskip("groq")
 
 from speech_recognition import AudioData, Recognizer
 from speech_recognition.recognizers.whisper_api import groq

--- a/tests/recognizers/whisper_api/test_openai.py
+++ b/tests/recognizers/whisper_api/test_openai.py
@@ -4,10 +4,10 @@ import httpx
 import pytest
 import respx
 
-pytest.importorskip("openai")
-
 from speech_recognition import AudioData, Recognizer
 from speech_recognition.recognizers.whisper_api import openai
+
+pytest.importorskip("openai")
 
 
 @pytest.fixture

--- a/tests/recognizers/whisper_api/test_openai.py
+++ b/tests/recognizers/whisper_api/test_openai.py
@@ -4,6 +4,8 @@ import httpx
 import pytest
 import respx
 
+pytest.importorskip("openai")
+
 from speech_recognition import AudioData, Recognizer
 from speech_recognition.recognizers.whisper_api import openai
 

--- a/tests/recognizers/whisper_api/test_openai_compatible.py
+++ b/tests/recognizers/whisper_api/test_openai_compatible.py
@@ -2,9 +2,9 @@ from unittest.mock import MagicMock
 
 import pytest
 
-pytest.importorskip("openai")
-
 from speech_recognition import AudioData, Recognizer
+
+pytest.importorskip("openai")
 
 
 def test_transcribe_with_openai_compatible_api(httpserver, monkeypatch):

--- a/tests/recognizers/whisper_api/test_openai_compatible.py
+++ b/tests/recognizers/whisper_api/test_openai_compatible.py
@@ -1,5 +1,9 @@
 from unittest.mock import MagicMock
 
+import pytest
+
+pytest.importorskip("openai")
+
 from speech_recognition import AudioData, Recognizer
 
 

--- a/tests/recognizers/whisper_local/test_faster_whisper.py
+++ b/tests/recognizers/whisper_local/test_faster_whisper.py
@@ -8,6 +8,9 @@ from unittest.mock import ANY, MagicMock, patch
 import numpy as np
 import pytest
 
+pytest.importorskip("faster_whisper")
+pytest.importorskip("soundfile")
+
 from speech_recognition import Recognizer
 from speech_recognition.audio import AudioData
 from speech_recognition.recognizers.whisper_local.faster_whisper import (

--- a/tests/recognizers/whisper_local/test_faster_whisper.py
+++ b/tests/recognizers/whisper_local/test_faster_whisper.py
@@ -8,14 +8,14 @@ from unittest.mock import ANY, MagicMock, patch
 import numpy as np
 import pytest
 
-pytest.importorskip("faster_whisper")
-pytest.importorskip("soundfile")
-
 from speech_recognition import Recognizer
 from speech_recognition.audio import AudioData
 from speech_recognition.recognizers.whisper_local.faster_whisper import (
     recognize,
 )
+
+pytest.importorskip("faster_whisper")
+pytest.importorskip("soundfile")
 
 if TYPE_CHECKING:
     from faster_whisper.transcribe import Segment, TranscriptionInfo

--- a/tests/recognizers/whisper_local/test_whisper.py
+++ b/tests/recognizers/whisper_local/test_whisper.py
@@ -5,11 +5,11 @@ from unittest.mock import ANY, MagicMock, patch
 import numpy as np
 import pytest
 
-pytest.importorskip("soundfile")
-pytest.importorskip("whisper")
-
 from speech_recognition import AudioData, Recognizer
 from speech_recognition.recognizers.whisper_local.whisper import recognize
+
+pytest.importorskip("soundfile")
+pytest.importorskip("whisper")
 
 
 @skipIf(sys.version_info >= (3, 14), "skip on Python 3.14")

--- a/tests/recognizers/whisper_local/test_whisper.py
+++ b/tests/recognizers/whisper_local/test_whisper.py
@@ -3,6 +3,10 @@ from unittest import TestCase, skipIf
 from unittest.mock import ANY, MagicMock, patch
 
 import numpy as np
+import pytest
+
+pytest.importorskip("soundfile")
+pytest.importorskip("whisper")
 
 from speech_recognition import AudioData, Recognizer
 from speech_recognition.recognizers.whisper_local.whisper import recognize

--- a/tests/test_recognition.py
+++ b/tests/test_recognition.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+import importlib.util
 import os
 import sys
 import unittest
 
 import speech_recognition as sr
+
+HAS_POCKETSPHINX = importlib.util.find_spec("pocketsphinx") is not None
 
 
 class TestRecognition(unittest.TestCase):
@@ -29,6 +32,7 @@ class TestRecognition(unittest.TestCase):
         # https://github.com/Uberi/speech_recognition/issues/743
         self.assertTrue("recognize_google" in attributes)
 
+    @unittest.skipUnless(HAS_POCKETSPHINX, "requires pocketsphinx extra")
     @unittest.skipIf(sys.platform.startswith("win"), "skip on Windows")
     def test_sphinx_english(self):
         audio = sr.AudioData.from_file(self.AUDIO_FILE_EN)

--- a/tests/test_special_features.py
+++ b/tests/test_special_features.py
@@ -5,7 +5,10 @@ import os
 import sys
 import unittest
 
+import pytest
 import speech_recognition as sr
+
+pytest.importorskip("pocketsphinx")
 
 
 class TestSpecialFeatures(unittest.TestCase):


### PR DESCRIPTION
## Summary
- split unit test CI into a base job, an all-extras regression job, and per-extra contract checks
- verify each extra in a fresh environment so missing transitive dependencies are not masked by other extras
- make optional-dependency tests skip cleanly when their extra is not installed

## Background
This follows the dependency mismatch discussed in #855 and fixed in #856.

That issue was easy to miss because CI mainly exercised an all-extras environment. In that setup, dependencies installed by one extra can mask missing dependencies in another extra. In the `faster-whisper` case, `soundfile` could be present because of other installs, so the `faster-whisper` packaging contract was not being verified in isolation.

## What This Changes
- add a `base` job that installs only `.[dev]`
- keep the existing all-extras regression coverage
- add `extra-contracts` jobs that create a fresh environment per extra and run targeted verification
- update optional-dependency tests to skip cleanly when their extra is not installed

## Testing
- `git diff --check`
- `python3 -m compileall tests speech_recognition`

A full local pytest run in a fresh CI-like environment was not possible from this worktree, so the new workflow is intended to validate the matrix in CI.