### PR TITLE
Support GPT Transcribe in the OpenAI recognizer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,7 +61,7 @@ Speech recognition engine/API support:
 * `Tensorflow <https://www.tensorflow.org/>`__
 * `Vosk API <https://github.com/alphacep/vosk-api/>`__ (works offline)
 * `OpenAI whisper <https://github.com/openai/whisper>`__ (works offline)
-* `OpenAI Whisper API <https://platform.openai.com/docs/guides/speech-to-text>`__
+* `OpenAI Transcription API <https://platform.openai.com/docs/guides/speech-to-text>`__
     * OpenAI compatible self-hosted endpoints (e.g. vLLM, Ollama)
 * `Groq Whisper API <https://console.groq.com/docs/speech-to-text>`__
 * `Cohere Transcribe API <https://docs.cohere.com/docs/transcribe>`__
@@ -120,7 +120,7 @@ To use all of the functionality of the library, you should have:
 * **Vosk** (required only if you need to use Vosk API speech recognition ``recognizer_instance.recognize_vosk``)
 * **Whisper** (required only if you need to use Whisper ``recognizer_instance.recognize_whisper``)
 * **Faster Whisper** (required only if you need to use Faster Whisper ``recognizer_instance.recognize_faster_whisper``)
-* **openai** (required only if you need to use OpenAI Whisper API speech recognition ``recognizer_instance.recognize_openai``)
+* **openai** (required only if you need to use OpenAI Transcription API speech recognition ``recognizer_instance.recognize_openai``)
     * includes OpenAI compatible self-hosted endpoints (e.g. vLLM, Ollama)
 * **groq** (required only if you need to use Groq Whisper API speech recognition ``recognizer_instance.recognize_groq``)
 * **cohere** (required only if you need to use Cohere Transcribe API speech recognition ``recognizer_instance.recognize_cohere_api``; install with ``pip install SpeechRecognition[cohere-api]``. Set ``CO_API_KEY`` as documented by the Cohere SDK.)
@@ -208,10 +208,10 @@ The library `faster-whisper <https://pypi.org/project/faster-whisper/>`__ is **r
 
 You can install it with ``python3 -m pip install SpeechRecognition[faster-whisper]``.
 
-OpenAI Whisper API (for OpenAI Whisper API users) 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+OpenAI Transcription API (for OpenAI Transcription API users)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The library `openai <https://pypi.org/project/openai/>`__ is **required if and only if you want to use OpenAI Whisper API** (``recognizer_instance.recognize_openai``).
+The library `openai <https://pypi.org/project/openai/>`__ is **required if and only if you want to use OpenAI Transcription API** (``recognizer_instance.recognize_openai``).
 
 You can install it with ``python3 -m pip install SpeechRecognition[openai]``.
 

--- a/examples/microphone_recognition.py
+++ b/examples/microphone_recognition.py
@@ -86,10 +86,13 @@ except sr.UnknownValueError:
 except sr.RequestError as e:
     print(f"Could not request results from Whisper; {e}")
 
-# recognize speech using Whisper API
+# recognize speech using the OpenAI Transcription API
 OPENAI_API_KEY = "INSERT OPENAI API KEY HERE"
 os.environ["OPENAI_API_KEY"] = OPENAI_API_KEY
 try:
-    print(f"OpenAI Whisper API thinks you said {r.recognize_openai(audio)}")
+    print(
+        "OpenAI Transcription API thinks you said "
+        f"{r.recognize_openai(audio)}"
+    )
 except sr.RequestError as e:
-    print(f"Could not request results from OpenAI Whisper API; {e}")
+    print(f"Could not request results from OpenAI Transcription API; {e}")

--- a/reference/library-reference.rst
+++ b/reference/library-reference.rst
@@ -323,7 +323,7 @@ When ``silence_aware`` is ``True``, chunk boundaries are snapped to nearby silen
 
 Raises ``ValueError`` if ``max_bytes`` is smaller than the WAV header overhead (44 bytes) plus one sample, or if ``len(frame_data)`` is not a multiple of ``sample_width`` (sample-aligned input is required so the byte budget is a hard ceiling).
 
-Example usage with the OpenAI Whisper API::
+Example usage with the OpenAI Transcription API::
 
     import speech_recognition as sr
 

--- a/speech_recognition/recognizers/whisper_api/openai.py
+++ b/speech_recognition/recognizers/whisper_api/openai.py
@@ -13,7 +13,10 @@ from speech_recognition.recognizers.whisper_api.base import (
 
 # https://platform.openai.com/docs/api-reference/audio/createTranscription#audio-createtranscription-model
 WhisperModel = Literal[
-    "whisper-1", "gpt-4o-transcribe", "gpt-4o-mini-transcribe"
+    "whisper-1",
+    "gpt-4o-transcribe",
+    "gpt-4o-mini-transcribe",
+    "gpt-transcribe",
 ]
 
 
@@ -38,7 +41,7 @@ def recognize(
     model: WhisperModel = "whisper-1",
     **kwargs: Unpack[OpenAIOptionalParameters],
 ) -> str:
-    """Performs speech recognition on ``audio_data`` (an ``AudioData`` instance), using the OpenAI Whisper API (and OpenAI-compatible self-hosted endpoints).
+    """Performs speech recognition on ``audio_data`` (an ``AudioData`` instance), using the OpenAI Transcription API (and OpenAI-compatible self-hosted endpoints).
 
     OpenAI hosted service: requires an OpenAI account; visit https://platform.openai.com/signup, then generate API Key in `API keys <https://platform.openai.com/api-keys>`__ in your project.
     Set environment variable ``OPENAI_API_KEY``; otherwise openai library will raise a ``openai.OpenAIError``.

--- a/tests/recognizers/whisper_api/test_openai.py
+++ b/tests/recognizers/whisper_api/test_openai.py
@@ -38,6 +38,30 @@ def test_transcribe_with_openai_whisper(respx_mock, setenv_openai_api_key):
 
 
 @respx.mock(assert_all_called=True, assert_all_mocked=True)
+def test_transcribe_with_gpt_transcribe(respx_mock, setenv_openai_api_key):
+    respx_mock.post(
+        "https://api.openai.com/v1/audio/transcriptions",
+        data__contains={"model": "gpt-transcribe"},
+    ).respond(
+        200,
+        json={
+            "text": "Transcription by GPT Transcribe",
+            "languages": [{"code": "en"}],
+        },
+    )
+
+    audio_data = MagicMock(spec=AudioData)
+    audio_data.get_wav_data.return_value = b"audio_data"
+
+    actual = openai.recognize(
+        MagicMock(spec=Recognizer), audio_data, model="gpt-transcribe"
+    )
+
+    assert actual == "Transcription by GPT Transcribe"
+    audio_data.get_wav_data.assert_called_once()
+
+
+@respx.mock(assert_all_called=True, assert_all_mocked=True)
 def test_transcribe_with_specified_language(respx_mock, setenv_openai_api_key):
     # https://github.com/Uberi/speech_recognition/issues/681
     respx_mock.post(


### PR DESCRIPTION
## Summary

- add `gpt-transcribe` to the models accepted by `recognize_openai`
- verify that the existing file-transcription path returns the transcript text for the new model
- rename user-facing references from the Whisper API to the OpenAI Transcription API

## Why

OpenAI's GPT Transcribe model uses the existing `/v1/audio/transcriptions` endpoint and returns a JSON transcription with a `text` field. The current recognizer already supports that request and response shape, but its typed model choices and CLI choices do not include `gpt-transcribe`.

This PR provides the first-stage, model-only integration. Support for GPT Transcribe-specific context fields such as `languages` and `keywords` is intentionally left for a follow-up.

## User impact

Users can select the new model with:

```python
recognizer.recognize_openai(audio, model="gpt-transcribe")
```

The default remains `whisper-1`, so existing callers are unaffected.

## Validation

- `pytest -q tests/recognizers/whisper_api/test_openai.py tests/recognizers/whisper_api/test_openai_compatible.py`
- `mypy --ignore-missing-imports speech_recognition/recognizers tests`
- `make lint`
- `make rstcheck`
