### PR TITLE
Drop Python 3.9 support

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -35,8 +35,6 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python-version: "3.9"
-          - os: ubuntu-latest
             python-version: "3.10"
           - os: ubuntu-latest
             python-version: "3.11"

--- a/README.rst
+++ b/README.rst
@@ -112,7 +112,7 @@ Requirements
 
 To use all of the functionality of the library, you should have:
 
-* **Python** 3.9+ (required)
+* **Python** 3.10+ (required)
 * **PyAudio** 0.2.11+ (required only if you need to use microphone input, ``Microphone``)
 * **PocketSphinx** (required only if you need to use the Sphinx recognizer, ``recognizer_instance.recognize_sphinx``)
 * **Google API Client Library for Python** (required only if you need to use the Google Cloud Speech API, ``recognizer_instance.recognize_google_cloud``)
@@ -134,7 +134,7 @@ The following sections go over the details of each requirement.
 Python
 ~~~~~~
 
-The first software requirement is `Python 3.9+ <https://www.python.org/downloads/>`__. This is required to use the library.
+The first software requirement is `Python 3.10+ <https://www.python.org/downloads/>`__. This is required to use the library.
 
 PyAudio (for microphone users)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "SpeechRecognition"
 dynamic = ["version"]
 description = "Library for performing speech recognition, with support for several engines and APIs, online and offline."
 readme = { file = "README.rst", content-type = "text/x-rst" }
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = "BSD-3-Clause"
 license-files = ["LICENSE.txt", "LICENSE-FLAC.txt"]
 authors = [
@@ -27,7 +27,6 @@ classifiers = [
   "Operating System :: Other OS",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
## Summary

- raise the minimum supported Python version from 3.9 to 3.10
- remove the Python 3.9 package classifier and CI job
- update the README requirements to document Python 3.10+

## Motivation

Python 3.9 is no longer supported upstream. Raising the minimum version keeps the package metadata, documentation, and CI matrix aligned with the supported Python versions.

## User impact

Future releases containing this change will require Python 3.10 or newer. Users who still depend on Python 3.9 will need to remain on an earlier SpeechRecognition release or upgrade Python.

## Validation

- Python 3.10 test run: 28 passed, 24 skipped, and 4 FLAC-dependent tests deselected because the bundled macOS FLAC executable is Intel-only
- README reStructuredText validation passed
- wheel and source distribution builds passed
- `twine check` passed for both distributions
- verified that the wheel metadata contains `Requires-Python: >=3.10`
